### PR TITLE
Fix spelling error in acinclude.m4

### DIFF
--- a/autoconf/acinclude.m4
+++ b/autoconf/acinclude.m4
@@ -36,17 +36,17 @@ AC_DEFUN([CS_CHECK_PBX], [
 					PBX_TEMPMODDIR="`${SED} -n 's/astmoddir[[[[:space:]]]]*=>[[[[:space:]]]]*\(.*\)$/\1/p' ${PBX_ETC}/asterisk.conf`"
 					if test -z "$PBX_TEMPMODDIR"; then
 						echo ""
-						AC_MSG_NOTICE([astmoddir could not be found in ${PBX_ETC}/asterisk.conf (your asterisk.conf file is faulty or not readable). Note: Path seperators use '=>', not '='])
+						AC_MSG_NOTICE([astmoddir could not be found in ${PBX_ETC}/asterisk.conf (your asterisk.conf file is faulty or not readable). Note: Path separators use '=>', not '='])
 					fi
 					PBX_VARLIB="`${SED} -n 's/astvarlibdir[[[[:space:]]]]*=>[[[[:space:]]]]*\(.*\)$/\1/p' ${PBX_ETC}/asterisk.conf`"
 					if test -z "$PBX_VARLIB"; then
 						echo ""
-						AC_MSG_NOTICE([astvarlibdir could not be found in ${PBX_ETC}/asterisk.conf (your asterisk.conf file is faulty or not readable). Note: Path seperators use '=>', not '='])
+						AC_MSG_NOTICE([astvarlibdir could not be found in ${PBX_ETC}/asterisk.conf (your asterisk.conf file is faulty or not readable). Note: Path separators use '=>', not '='])
 					fi
 					PBX_SBINDIR="`${SED} -n 's/astsbindir[[[[:space:]]]]*=>[[[[:space:]]]]*\(.*\)$/\1/p' ${PBX_ETC}/asterisk.conf`"
 					if test -z "$PBX_SBINDIR"; then
 						echo ""
-						AC_MSG_NOTICE([astsbindir could not be found in ${PBX_ETC}/asterisk.conf (your asterisk.conf file is faulty or not readable). Note: Path seperators use '=>', not '='])
+						AC_MSG_NOTICE([astsbindir could not be found in ${PBX_ETC}/asterisk.conf (your asterisk.conf file is faulty or not readable). Note: Path separators use '=>', not '='])
 					fi
 		 		else
 		 			PBX_TEMPMODDIR="$(${PKGCONFIG} --variable=moddir asterisk)"


### PR DESCRIPTION
Changes proposed by this Pull Request:
- Fixes a spelling error that was bugging me in acinclude.m4

Inform: @Developers

