### PR TITLE
Fix DirectRTP / Hold/Resume/Transfer/Loopback

### DIFF
--- a/src/pbx_impl/ast111/ast111.c
+++ b/src/pbx_impl/ast111/ast111.c
@@ -1736,7 +1736,7 @@ static int sccp_wrapper_asterisk111_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 		}
 
 		if (!codecs) {
-			sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk112_update_rtp_peer) NO Codecs\n", c->currentDeviceId);
+			sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk111_update_rtp_peer) NO Codecs\n", c->currentDeviceId);
 			result = -1;
 			break;
 		}
@@ -1768,7 +1768,6 @@ static int sccp_wrapper_asterisk111_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 
 		PBX_RTP_TYPE *instance = { 0, };
 		struct sockaddr_storage sas = { 0, };
-		//struct sockaddr_in sin = { 0, };
 		struct ast_sockaddr sin_tmp;
 		boolean_t directmedia = FALSE;
 
@@ -1783,32 +1782,41 @@ static int sccp_wrapper_asterisk111_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 		if (d->directrtp && d->nat < SCCP_NAT_ON && !nat_active && !c->conference) {			// asume directrtp
 			ast_rtp_instance_get_remote_address(instance, &sin_tmp);
 			memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
-			//ast_sockaddr_to_sin(&sin_tmp, &sin);
-			if (d->nat == SCCP_NAT_OFF) {								// forced nat off to circumvent autodetection + direcrtp, requires checking both phone_ip and external session ip address against devices permit/deny
-				struct ast_sockaddr sin_local;
-				struct sockaddr_storage localsas = { 0, };
-				ast_rtp_instance_get_local_address(instance, &sin_local);
-				memcpy(&localsas, &sin_local, sizeof(struct sockaddr_storage));
-				if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW && sccp_apply_ha(d->ha, &localsas) == AST_SENSE_ALLOW) {
+			if (!ast_sockaddr_isnull(&sin_tmp)) {
+				memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
+				if (d->nat == SCCP_NAT_OFF) {							// forced nat off to circumvent autodetection + direcrtp, requires checking both phone_ip and external session ip address against devices permit/deny
+					struct ast_sockaddr sin_local;
+					struct sockaddr_storage localsas = { 0, };
+					ast_rtp_instance_get_local_address(instance, &sin_local);
+					memcpy(&localsas, &sin_local, sizeof(struct sockaddr_storage));
+					if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW && sccp_apply_ha(d->ha, &localsas) == AST_SENSE_ALLOW) {
+						directmedia = TRUE;
+					}
+				} else if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW) {			// check remote sin against local device acl (to match netmask)
 					directmedia = TRUE;
+					//ast_channel_defer_dtmf(ast);
 				}
-			} else if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW) {					// check remote sin against local device acl (to match netmask)
-					directmedia = TRUE;
-					//                ast_channel_defer_dtmf(ast);
+			} else {
+				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk111_update_rtp_peer) failed to get remote ip-address\n", c->currentDeviceId);
+				return -1;
 			}
 		}
 		if (!directmedia) {										// fallback to indirectrtp
 			ast_rtp_instance_get_local_address(instance, &sin_tmp);
-			//        ast_sockaddr_to_sin(&sin_tmp, &sin);
-			//        sin.sin_addr.s_addr = sin.sin_addr.s_addr ? sin.sin_addr.s_addr : d->session->ourip.s_addr;
-			memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
-			sccp_session_getOurIP(d->session, &sas, sccp_netsock_is_IPv4(&sas) ? AF_INET : AF_INET6);
+			if (!ast_sockaddr_isnull(&sin_tmp)) {
+				memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
+				sccp_session_getOurIP(d->session, &sas, sccp_netsock_is_IPv4(&sas) ? AF_INET : AF_INET6);
+			} else {
+				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk111_update_rtp_peer) failed to get local ip-address\n", c->currentDeviceId);
+				return -1;
+			}
 		}
-
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk111_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s) => directmedia=%s\n", c->currentDeviceId, sccp_netsock_stringify(&sas), S_COR(d->directrtp, "yes", "no"),
-					  sccp_nat2str(d->nat),
-					  S_COR(!nat_active, "yes", "no"), S_COR(directmedia, "yes", "no"), S_COR(directmedia, "yes", "no")
-		    );
+		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk111_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s && !c->conference:%s) => directmedia=%s\n",
+			  c->currentDeviceId, sccp_netsock_stringify(&sas), S_COR(d->directrtp, "yes", "no"),
+			  sccp_nat2str(d->nat),
+			  S_COR(!nat_active, "yes", "no"), S_COR(directmedia, "yes", "no"), S_COR(directmedia, "yes", "no"),
+			  S_COR(!c->conference, "yes", "no")
+		);
 
 		if (rtp) {											// send peer info to phone
 			sccp_rtp_set_peer(c, &c->rtp.audio, &sas);

--- a/src/pbx_impl/ast113/ast113.c
+++ b/src/pbx_impl/ast113/ast113.c
@@ -1911,7 +1911,6 @@ static int sccp_wrapper_asterisk113_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 
 		PBX_RTP_TYPE *instance = { 0, };
 		struct sockaddr_storage sas = { 0, };
-		//struct sockaddr_in sin = { 0, };
 		struct ast_sockaddr sin_tmp;
 		boolean_t directmedia = FALSE;
 
@@ -1942,31 +1941,42 @@ static int sccp_wrapper_asterisk113_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 		if (d->directrtp && d->nat < SCCP_NAT_ON && !nat_active && !c->conference) {			// asume directrtp
 			ast_rtp_instance_get_remote_address(instance, &sin_tmp);
 			memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
-			//ast_sockaddr_to_sin(&sin_tmp, &sin);
-			if (d->nat == SCCP_NAT_OFF) {								// forced nat off to circumvent autodetection + direcrtp, requires checking both phone_ip and external session ip address against devices permit/deny
-				struct ast_sockaddr sin_local;
-				struct sockaddr_storage localsas = { 0, };
-				ast_rtp_instance_get_local_address(instance, &sin_local);
-				memcpy(&localsas, &sin_local, sizeof(struct sockaddr_storage));
-				if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW && sccp_apply_ha(d->ha, &localsas) == AST_SENSE_ALLOW) {
+			if (!ast_sockaddr_isnull(&sin_tmp)) {
+				memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
+				if (d->nat == SCCP_NAT_OFF) {							// forced nat off to circumvent autodetection + direcrtp, requires checking both phone_ip and external session ip address against devices permit/deny
+					struct ast_sockaddr sin_local;
+					struct sockaddr_storage localsas = { 0, };
+					ast_rtp_instance_get_local_address(instance, &sin_local);
+					memcpy(&localsas, &sin_local, sizeof(struct sockaddr_storage));
+					if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW && sccp_apply_ha(d->ha, &localsas) == AST_SENSE_ALLOW) {
+						directmedia = TRUE;
+					}
+				} else if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW) {			// check remote sin against local device acl (to match netmask)
 					directmedia = TRUE;
+					//ast_channel_defer_dtmf(ast);
 				}
-			} else if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW) {					// check remote sin against local device acl (to match netmask)
-				directmedia = TRUE;
-				// ast_channel_defer_dtmf(ast);
+			} else {
+				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk113_update_rtp_peer) failed to get remote ip-address\n", c->currentDeviceId);
+				return -1;
 			}
 		}
 		if (!directmedia) {										// fallback to indirectrtp
 			ast_rtp_instance_get_local_address(instance, &sin_tmp);
-			memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
-			sccp_session_getOurIP(d->session, &sas, sccp_netsock_is_IPv4(&sas) ? AF_INET : AF_INET6);
+			if (!ast_sockaddr_isnull(&sin_tmp)) {
+				memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
+				sccp_session_getOurIP(d->session, &sas, sccp_netsock_is_IPv4(&sas) ? AF_INET : AF_INET6);
+			} else {
+				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk113_update_rtp_peer) failed to get local ip-address\n", c->currentDeviceId);
+				return -1;
+			}
 		}
-
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk113_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s) => directmedia=%s\n", c->currentDeviceId, sccp_netsock_stringify(&sas), S_COR(d->directrtp, "yes", "no"),
-					  sccp_nat2str(d->nat),
-					  S_COR(!nat_active, "yes", "no"), S_COR(directmedia, "yes", "no"), S_COR(directmedia, "yes", "no")
-		    );
-
+		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk113_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s && !c->conference:%s) => directmedia=%s\n",
+			  c->currentDeviceId, sccp_netsock_stringify(&sas), S_COR(d->directrtp, "yes", "no"),
+			  sccp_nat2str(d->nat),
+			  S_COR(!nat_active, "yes", "no"), S_COR(directmedia, "yes", "no"), S_COR(directmedia, "yes", "no"),
+			  S_COR(!c->conference, "yes", "no")
+		);
+		
 		if (rtp) {											// send peer info to phone
 			sccp_rtp_set_peer(c, &c->rtp.audio, &sas);
 			c->rtp.audio.directMedia = directmedia;

--- a/src/pbx_impl/ast113/ast113.c
+++ b/src/pbx_impl/ast113/ast113.c
@@ -2004,6 +2004,7 @@ static int sccp_wrapper_asterisk113_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 				}
 			} else {
 				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk113_update_rtp_peer) failed to get remote ip-address\n", c->currentDeviceId);
+				//ast_queue_control(c->owner, AST_CONTROL_UPDATE_RTP_PEER);
 				return -1;
 			}
 		}
@@ -2016,8 +2017,6 @@ static int sccp_wrapper_asterisk113_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk113_update_rtp_peer) failed to get local ip-address\n", c->currentDeviceId);
 				return -1;
 			}
-		} else {
-			ast_queue_control(c->owner, AST_CONTROL_UPDATE_RTP_PEER);
 		}
 		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk113_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s && !c->conference:%s) => directmedia=%s\n",
 			  c->currentDeviceId, sccp_netsock_stringify(&sas), S_COR(d->directrtp, "yes", "no"),

--- a/src/pbx_impl/ast114/ast114.c
+++ b/src/pbx_impl/ast114/ast114.c
@@ -1899,7 +1899,6 @@ static int sccp_wrapper_asterisk114_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 
 		PBX_RTP_TYPE *instance = { 0, };
 		struct sockaddr_storage sas = { 0, };
-		//struct sockaddr_in sin = { 0, };
 		struct ast_sockaddr sin_tmp;
 		boolean_t directmedia = FALSE;
 
@@ -1929,31 +1928,43 @@ static int sccp_wrapper_asterisk114_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 
 		if (d->directrtp && d->nat < SCCP_NAT_ON && !nat_active && !c->conference) {			// asume directrtp
 			ast_rtp_instance_get_remote_address(instance, &sin_tmp);
-			memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
-			//ast_sockaddr_to_sin(&sin_tmp, &sin);
-			if (d->nat == SCCP_NAT_OFF) {								// forced nat off to circumvent autodetection + direcrtp, requires checking both phone_ip and external session ip address against devices permit/deny
-				struct ast_sockaddr sin_local;
-				struct sockaddr_storage localsas = { 0, };
-				ast_rtp_instance_get_local_address(instance, &sin_local);
-				memcpy(&localsas, &sin_local, sizeof(struct sockaddr_storage));
-				if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW && sccp_apply_ha(d->ha, &localsas) == AST_SENSE_ALLOW) {
+			if (!ast_sockaddr_isnull(&sin_tmp)) {
+				memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
+				if (d->nat == SCCP_NAT_OFF) {							// forced nat off to circumvent autodetection + direcrtp, requires checking both phone_ip and external session ip address against devices permit/deny
+					struct ast_sockaddr sin_local;
+					struct sockaddr_storage localsas = { 0, };
+					ast_rtp_instance_get_local_address(instance, &sin_local);
+					memcpy(&localsas, &sin_local, sizeof(struct sockaddr_storage));
+					if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW && sccp_apply_ha(d->ha, &localsas) == AST_SENSE_ALLOW) {
+						directmedia = TRUE;
+					}
+				} else if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW) {			// check remote sin against local device acl (to match netmask)
 					directmedia = TRUE;
+					// ast_channel_defer_dtmf(ast);
 				}
-			} else if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW) {					// check remote sin against local device acl (to match netmask)
-				directmedia = TRUE;
-				// ast_channel_defer_dtmf(ast);
+			} else {
+				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_update_rtp_peer) failed to get remote ip-address\n", c->currentDeviceId);
+				return -1;
 			}
 		}
 		if (!directmedia) {										// fallback to indirectrtp
+			sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_update_rtp_peer) falling back to indirect\n", c->currentDeviceId)
 			ast_rtp_instance_get_local_address(instance, &sin_tmp);
-			memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
-			sccp_session_getOurIP(d->session, &sas, sccp_netsock_is_IPv4(&sas) ? AF_INET : AF_INET6);
+			if (!ast_sockaddr_isnull(&sin_tmp)) {
+				memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
+				sccp_session_getOurIP(d->session, &sas, sccp_netsock_is_IPv4(&sas) ? AF_INET : AF_INET6);
+			} else {
+				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_update_rtp_peer) failed to get local ip-address\n", c->currentDeviceId);
+				return -1;
+			}
 		}
 
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s) => directmedia=%s\n", c->currentDeviceId, sccp_netsock_stringify(&sas), S_COR(d->directrtp, "yes", "no"),
-					  sccp_nat2str(d->nat),
-					  S_COR(!nat_active, "yes", "no"), S_COR(directmedia, "yes", "no"), S_COR(directmedia, "yes", "no")
-		    );
+		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s && !c->conference:%s) => directmedia=%s\n",
+			  c->currentDeviceId, sccp_netsock_stringify(&sas), S_COR(d->directrtp, "yes", "no"),
+			  sccp_nat2str(d->nat),
+			  S_COR(!nat_active, "yes", "no"), S_COR(directmedia, "yes", "no"), S_COR(directmedia, "yes", "no"),
+			  S_COR(!c->conference, "yes", "no")
+		);
 
 		if (rtp) {											// send peer info to phone
 			sccp_rtp_set_peer(c, &c->rtp.audio, &sas);

--- a/src/pbx_impl/ast114/ast114.c
+++ b/src/pbx_impl/ast114/ast114.c
@@ -703,6 +703,10 @@ static int sccp_wrapper_asterisk114_indicate(PBX_CHANNEL_TYPE * ast, int ind, co
 			break;
 
 			/* when the bridged channel hold/unhold the call we are notified here */
+		case AST_CONTROL_UPDATE_RTP_PEER:
+			sccp_log((DEBUGCAT_PBX | DEBUGCAT_INDICATE)) (VERBOSE_PREFIX_3 "SCCP: UPDATE RTP PEER Request\n");
+			res = 0;
+			break;
 		case AST_CONTROL_HOLD:
 			sccp_asterisk_moh_start(ast, (const char *) data, c->musicclass);
 			res = 0;
@@ -728,7 +732,7 @@ static int sccp_wrapper_asterisk114_indicate(PBX_CHANNEL_TYPE * ast, int ind, co
 			break;
 
 		case AST_CONTROL_TRANSFER:
-			ast_log(LOG_NOTICE, "%s: Ast Control Transfer: %d", c->designator, *(int *)data);
+			sccp_log((DEBUGCAT_PBX | DEBUGCAT_INDICATE)) (VERBOSE_PREFIX_3 "%s: Ast Control Transfer: %d", c->designator, *(int *)data);
 			//sccp_asterisk_connectedline(c, data, datalen);
 			res = 0;
 			break;
@@ -912,8 +916,10 @@ static int sccp_wrapper_asterisk114_setNativeAudioFormats(constChannelPtr channe
 	ast_format_cap_remove_by_type(ast_channel_nativeformats(channel->owner), AST_MEDIA_TYPE_AUDIO);
 	for (i = 0; i < length; i++) {
 		format = sccp_asterisk13_skinny2ast_format(codec[i]);
-		framing = ast_format_get_default_ms(format);
-		ast_format_cap_append(ast_channel_nativeformats(channel->owner), format, framing);
+		if (format != ast_format_none) {
+			framing = ast_format_get_default_ms(format);
+			ast_format_cap_append(ast_channel_nativeformats(channel->owner), format, framing);
+		}
 	}
 
 	return 1;
@@ -931,8 +937,10 @@ static int sccp_wrapper_asterisk114_setNativeVideoFormats(constChannelPtr channe
 
 	for (i = 0; i < length; i++) {
 		format = sccp_asterisk13_skinny2ast_format(codec);
-		framing = ast_format_get_default_ms(format);
-		ast_format_cap_append(ast_channel_nativeformats(channel->owner), format, framing);
+		if (format != ast_format_none) {
+			framing = ast_format_get_default_ms(format);
+			ast_format_cap_append(ast_channel_nativeformats(channel->owner), format, framing);
+		}
 	}
 	return 1;
 }
@@ -1342,20 +1350,21 @@ static boolean_t sccp_wrapper_asterisk114_getPickupExtension(constChannelPtr cha
 static uint8_t sccp_wrapper_asterisk114_get_payloadType(const struct sccp_rtp *rtp, skinny_codec_t codec)
 {
 	struct ast_format *astCodec = sccp_asterisk13_skinny2ast_format(codec);
-	int payload;
-
-	// ast_format_set(&astCodec, skinny_codec2pbx_codec(codec), 0);
-	payload = ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(rtp->instance), skinny_codec2pbx_codec(codec), astCodec, 0);
-
+	int payload = 0;
+	if (astCodec != ast_format_none) {
+		payload = ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(rtp->instance), skinny_codec2pbx_codec(codec), astCodec, 0);
+	}
 	return payload;
 }
 
 static int sccp_wrapper_asterisk114_get_sampleRate(skinny_codec_t codec)
 {
 	struct ast_format *astCodec = sccp_asterisk13_skinny2ast_format(codec);
-
-	// ast_format_set(&astCodec, skinny_codec2pbx_codec(codec), 0);
-	return ast_rtp_lookup_sample_rate2(1, astCodec, 0);
+	int sampleRate = 0;
+	if (astCodec != ast_format_none) {
+		sampleRate = ast_rtp_lookup_sample_rate2(1, astCodec, 0);
+	}
+	return sampleRate;
 }
 
 static sccp_extension_status_t sccp_wrapper_asterisk114_extensionStatus(constChannelPtr channel)
@@ -1756,102 +1765,65 @@ static enum ast_bridge_result sccp_wrapper_asterisk114_rtpBridge(PBX_CHANNEL_TYP
 #endif
 #endif
 
+static enum ast_rtp_glue_result get_rtp_info(PBX_CHANNEL_TYPE * ast, PBX_RTP_TYPE ** rtp, sccp_rtp_type_t rtptype)
+{
+	//AUTO_RELEASE(sccp_channel_t, c , get_sccp_channel_from_pbx_channel(ast));				// not following the refcount rules... channel is already retained
+	sccp_channel_t *c = NULL;
+	sccp_rtp_info_t rtpInfo = SCCP_RTP_INFO_NORTP;
+	struct sccp_rtp *RTP = NULL;
+	enum ast_rtp_glue_result res = AST_RTP_GLUE_RESULT_REMOTE;
+
+	if (!(c = CS_AST_CHANNEL_PVT(ast))) {
+		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "SCCP: (get_rtp_info) NO PVT\n");
+		return AST_RTP_GLUE_RESULT_FORBID;
+	}
+
+	if (pbx_channel_state(ast) != AST_STATE_UP) {
+		sccp_log((DEBUGCAT_CHANNEL | DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (get_rtp_info) Asterisk requested EarlyRTP peer for channel %s\n", c->currentDeviceId, pbx_channel_name(ast));
+	}
+
+	if (rtptype == SCCP_RTP_AUDIO) {
+		rtpInfo = sccp_rtp_getAudioPeerInfo(c, &RTP);
+	}
+#ifdef CS_SCCP_VIDEO
+	if (rtptype == SCCP_RTP_VIDEO) {
+		rtpInfo = sccp_rtp_getVideoPeerInfo(c, &RTP);
+	}
+#endif
+	if (rtpInfo == SCCP_RTP_INFO_NORTP || RTP == NULL) {
+		return AST_RTP_GLUE_RESULT_FORBID;
+	}
+
+	*rtp = RTP->instance;
+	if (!*rtp) {
+		return AST_RTP_GLUE_RESULT_FORBID;
+	}
+	ao2_ref(*rtp, +1);
+	if (ast_test_flag(GLOB(global_jbconf), AST_JB_FORCED)) {
+		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (get_rtp_info) JitterBuffer is Forced. AST_RTP_GET_FAILED -> local bridging\n", c->currentDeviceId);
+		return AST_RTP_GLUE_RESULT_LOCAL;
+	}
+
+	if (!(rtpInfo & SCCP_RTP_INFO_ALLOW_DIRECTRTP)) {
+		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (get_rtp_info) Direct RTP disabled ->  Using AST_RTP_TRY_PARTIAL for channel %s\n", c->currentDeviceId, pbx_channel_name(ast));
+		return AST_RTP_GLUE_RESULT_LOCAL;
+	}
+
+	sccp_log((DEBUGCAT_RTP | DEBUGCAT_HIGH)) (VERBOSE_PREFIX_1 "%s: (get_rtp_info) Channel %s Returning %s RTP: %s\n", c->currentDeviceId, sccp_rtp_type2str(rtptype), pbx_channel_name(ast), ((res == 2) ? "indirect-rtp" : ((res == 1) ? "direct-rtp" : "forbid direcrtrtp")));
+	return res;
+}
+
 static enum ast_rtp_glue_result sccp_wrapper_asterisk114_get_rtp_info(PBX_CHANNEL_TYPE * ast, PBX_RTP_TYPE ** rtp)
 {
-	//AUTO_RELEASE(sccp_channel_t, c , get_sccp_channel_from_pbx_channel(ast));				// not following the refcount rules... channel is already retained
-	sccp_channel_t *c = NULL;
-	sccp_rtp_info_t rtpInfo = SCCP_RTP_INFO_NORTP;
-	struct sccp_rtp *audioRTP = NULL;
-	enum ast_rtp_glue_result res = AST_RTP_GLUE_RESULT_REMOTE;
-
-	if (!(c = CS_AST_CHANNEL_PVT(ast))) {
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "SCCP: (asterisk114_get_rtp_info) NO PVT\n");
-		return AST_RTP_GLUE_RESULT_FORBID;
-	}
-
-	if (pbx_channel_state(ast) != AST_STATE_UP) {
-		sccp_log((DEBUGCAT_CHANNEL | DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_rtp_info) Asterisk requested EarlyRTP peer for channel %s\n", c->currentDeviceId, pbx_channel_name(ast));
-	} else {
-		sccp_log((DEBUGCAT_CHANNEL | DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_rtp_info) Asterisk requested RTP peer for channel %s\n", c->currentDeviceId, pbx_channel_name(ast));
-	}
-
-	rtpInfo = sccp_rtp_getAudioPeerInfo(c, &audioRTP);
-	if (rtpInfo == SCCP_RTP_INFO_NORTP) {
-		return AST_RTP_GLUE_RESULT_FORBID;
-	}
-
-	*rtp = audioRTP->instance;
-	if (!*rtp) {
-		return AST_RTP_GLUE_RESULT_FORBID;
-	}
-	// struct ast_sockaddr ast_sockaddr_tmp;
-	// ast_rtp_instance_get_remote_address(*rtp, &ast_sockaddr_tmp);
-	// sccp_log((DEBUGCAT_RTP | DEBUGCAT_HIGH)) (VERBOSE_PREFIX_3 "%s: (asterisk114_get_rtp_info) remote address:'%s:%d'\n", c->currentDeviceId, ast_sockaddr_stringify_host(&ast_sockaddr_tmp), ast_sockaddr_port(&ast_sockaddr_tmp));
-
-	ao2_ref(*rtp, +1);
-	if (ast_test_flag(GLOB(global_jbconf), AST_JB_FORCED)) {
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_rtp_info) JitterBuffer is Forced. AST_RTP_GET_FAILED\n", c->currentDeviceId);
-		return AST_RTP_GLUE_RESULT_LOCAL;
-	}
-
-	if (!(rtpInfo & SCCP_RTP_INFO_ALLOW_DIRECTRTP)) {
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_rtp_info) Direct RTP disabled ->  Using AST_RTP_TRY_PARTIAL for channel %s\n", c->currentDeviceId, pbx_channel_name(ast));
-		return AST_RTP_GLUE_RESULT_LOCAL;
-	}
-
-	sccp_log((DEBUGCAT_RTP | DEBUGCAT_HIGH)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_rtp_info) Channel %s Returning res: %s\n", c->currentDeviceId, pbx_channel_name(ast), ((res == 2) ? "indirect-rtp" : ((res == 1) ? "direct-rtp" : "forbid")));
-	return res;
+	return get_rtp_info(ast, rtp, SCCP_RTP_AUDIO);
 }
-
-static enum ast_rtp_glue_result sccp_wrapper_asterisk114_get_vrtp_info(PBX_CHANNEL_TYPE * ast, PBX_RTP_TYPE ** rtp)
-{
-	//AUTO_RELEASE(sccp_channel_t, c , get_sccp_channel_from_pbx_channel(ast));				// not following the refcount rules... channel is already retained
-	sccp_channel_t *c = NULL;
-	sccp_rtp_info_t rtpInfo = SCCP_RTP_INFO_NORTP;
-	struct sccp_rtp *videoRTP = NULL;
-	enum ast_rtp_glue_result res = AST_RTP_GLUE_RESULT_REMOTE;
-
-	if (!(c = CS_AST_CHANNEL_PVT(ast))) {
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "SCCP: (asterisk114_get_vrtp_info) NO PVT\n");
-		return AST_RTP_GLUE_RESULT_FORBID;
-	}
-
-	if (pbx_channel_state(ast) != AST_STATE_UP) {
-		sccp_log((DEBUGCAT_CHANNEL | DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_vrtp_info) Asterisk requested EarlyRTP peer for channel %s\n", c->currentDeviceId, pbx_channel_name(ast));
-	} else {
-		sccp_log((DEBUGCAT_CHANNEL | DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_vrtp_info) Asterisk requested RTP peer for channel %s\n", c->currentDeviceId, pbx_channel_name(ast));
-	}
 
 #ifdef CS_SCCP_VIDEO
-	rtpInfo = sccp_rtp_getVideoPeerInfo(c, &videoRTP);
-#endif
-	if (rtpInfo == SCCP_RTP_INFO_NORTP) {
-		return AST_RTP_GLUE_RESULT_FORBID;
-	}
-
-	*rtp = videoRTP->instance;
-	if (!*rtp) {
-		return AST_RTP_GLUE_RESULT_FORBID;
-	}
-	// struct ast_sockaddr ast_sockaddr_tmp;
-	// ast_rtp_instance_get_remote_address(*rtp, &ast_sockaddr_tmp);
-	// sccp_log((DEBUGCAT_RTP | DEBUGCAT_HIGH)) (VERBOSE_PREFIX_3 "%s: (asterisk114_get_rtp_info) remote address:'%s:%d'\n", c->currentDeviceId, ast_sockaddr_stringify_host(&ast_sockaddr_tmp), ast_sockaddr_port(&ast_sockaddr_tmp));
-#ifdef HAVE_PBX_RTP_ENGINE_H
-	ao2_ref(*rtp, +1);
-#endif
-	if (ast_test_flag(GLOB(global_jbconf), AST_JB_FORCED)) {
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_vrtp_info) JitterBuffer is Forced. AST_RTP_GET_FAILED\n", c->currentDeviceId);
-		return AST_RTP_GLUE_RESULT_FORBID;
-	}
-
-	if (!(rtpInfo & SCCP_RTP_INFO_ALLOW_DIRECTRTP)) {
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_vrtp_info) Direct RTP disabled ->  Using AST_RTP_TRY_PARTIAL for channel %s\n", c->currentDeviceId, pbx_channel_name(ast));
-		return AST_RTP_GLUE_RESULT_LOCAL;
-	}
-
-	sccp_log((DEBUGCAT_RTP | DEBUGCAT_HIGH)) (VERBOSE_PREFIX_1 "%s: (asterisk114_get_vrtp_info) Channel %s Returning res: %s\n", c->currentDeviceId, pbx_channel_name(ast), ((res == 2) ? "indirect-rtp" : ((res == 1) ? "direct-rtp" : "forbid")));
-	return res;
+static enum ast_rtp_glue_result sccp_wrapper_asterisk114_get_vrtp_info(PBX_CHANNEL_TYPE * ast, PBX_RTP_TYPE ** rtp)
+{
+	return get_rtp_info(ast, rtp, SCCP_RTP_VIDEO);
 }
+#endif
 
 static int sccp_wrapper_asterisk114_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_RTP_TYPE * rtp, PBX_RTP_TYPE * vrtp, PBX_RTP_TYPE * trtp, const struct ast_format_cap *codecs, int nat_active)
 {
@@ -1957,6 +1929,8 @@ static int sccp_wrapper_asterisk114_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_update_rtp_peer) failed to get local ip-address\n", c->currentDeviceId);
 				return -1;
 			}
+		} else {
+		        ast_queue_control(c->owner, AST_CONTROL_UPDATE_RTP_PEER);
 		}
 
 		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk114_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s && !c->conference:%s) => directmedia=%s\n",
@@ -1998,13 +1972,17 @@ static void sccp_wrapper_asterisk114_getCodec(PBX_CHANNEL_TYPE * ast, struct ast
 	ast_debug(10, "asterisk requests format for channel %s, readFormat: %s(%d)\n", pbx_channel_name(ast), codec2str(channel->rtp.audio.readFormat), channel->rtp.audio.readFormat);
 	for (i = 0; i < ARRAY_LEN(channel->preferences.audio); i++) {
 		ast_format = sccp_asterisk13_skinny2ast_format(channel->preferences.audio[i]);
-		framing = ast_format_get_default_ms(ast_format);
-		ast_format_cap_append(result, ast_format, framing);
+		if (ast_format != ast_format_none) {
+			framing = ast_format_get_default_ms(ast_format);
+			ast_format_cap_append(result, ast_format, framing);
+		}
 	}
 	for (i = 0; i < ARRAY_LEN(channel->preferences.video); i++) {
 		ast_format = sccp_asterisk13_skinny2ast_format(channel->preferences.video[i]);
-		framing = ast_format_get_default_ms(ast_format);
-		ast_format_cap_append(result, ast_format, framing);
+		if (ast_format != ast_format_none) {
+			framing = ast_format_get_default_ms(ast_format);
+			ast_format_cap_append(result, ast_format, framing);
+		}
 	}
 
 	return;
@@ -2297,10 +2275,11 @@ static boolean_t sccp_wrapper_asterisk114_setWriteFormat(constChannelPtr channel
 
 	// ast_format_set(&tmp_format, skinny_codec2pbx_codec(codec), 0);
 	ast_format = sccp_asterisk13_skinny2ast_format(codec);
-	framing = ast_format_get_default_ms(ast_format);
-
-	ast_format_cap_append(cap, ast_format, framing);
-	ast_set_write_format_from_cap(channel->owner, cap);
+	if (ast_format != ast_format_none) {
+		framing = ast_format_get_default_ms(ast_format);
+		ast_format_cap_append(cap, ast_format, framing);
+		ast_set_write_format_from_cap(channel->owner, cap);
+	}
 	ao2_ref(cap, -1);
 	cap = NULL;
 
@@ -2329,10 +2308,11 @@ static boolean_t sccp_wrapper_asterisk114_setReadFormat(constChannelPtr channel,
 	// ast_format_set(&tmp_format, skinny_codec2pbx_codec(codec), 0);
 	// ast_format_cap_add(cap, &tmp_format);
 	ast_format = sccp_asterisk13_skinny2ast_format(codec);
-	framing = ast_format_get_default_ms(ast_format);
-	ast_format_cap_append(cap, ast_format, framing);
-
-	ast_set_read_format_from_cap(channel->owner, cap);
+	if (ast_format != ast_format_none) {
+		framing = ast_format_get_default_ms(ast_format);
+		ast_format_cap_append(cap, ast_format, framing);
+		ast_set_read_format_from_cap(channel->owner, cap);
+	}
 	ao2_ref(cap, -1);
 	cap = NULL;
 
@@ -3396,7 +3376,9 @@ static int register_channel_tech(struct ast_channel_tech *tech)
 		return -1;
 	}
 	ast_format_cap_append_by_type(tech->capabilities, AST_MEDIA_TYPE_AUDIO);
+#ifdef CS_SCCP_VIDEO
 	ast_format_cap_append_by_type(tech->capabilities, AST_MEDIA_TYPE_VIDEO);
+#endif
 	//ast_format_cap_append_by_type(tech->capabilities, AST_MEDIA_TYPE_TEXT);
 
 	if (ast_channel_register(tech)) {

--- a/src/pbx_impl/ast115/ast115.c
+++ b/src/pbx_impl/ast115/ast115.c
@@ -1899,7 +1899,6 @@ static int sccp_wrapper_asterisk115_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 
 		PBX_RTP_TYPE *instance = { 0, };
 		struct sockaddr_storage sas = { 0, };
-		//struct sockaddr_in sin = { 0, };
 		struct ast_sockaddr sin_tmp;
 		boolean_t directmedia = FALSE;
 
@@ -1929,31 +1928,43 @@ static int sccp_wrapper_asterisk115_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_
 
 		if (d->directrtp && d->nat < SCCP_NAT_ON && !nat_active && !c->conference) {			// asume directrtp
 			ast_rtp_instance_get_remote_address(instance, &sin_tmp);
-			memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
-			//ast_sockaddr_to_sin(&sin_tmp, &sin);
-			if (d->nat == SCCP_NAT_OFF) {								// forced nat off to circumvent autodetection + direcrtp, requires checking both phone_ip and external session ip address against devices permit/deny
-				struct ast_sockaddr sin_local;
-				struct sockaddr_storage localsas = { 0, };
-				ast_rtp_instance_get_local_address(instance, &sin_local);
-				memcpy(&localsas, &sin_local, sizeof(struct sockaddr_storage));
-				if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW && sccp_apply_ha(d->ha, &localsas) == AST_SENSE_ALLOW) {
+			if (!ast_sockaddr_isnull(&sin_tmp)) {
+				memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
+				if (d->nat == SCCP_NAT_OFF) {							// forced nat off to circumvent autodetection + direcrtp, requires checking both phone_ip and external session ip address against devices permit/deny
+					struct ast_sockaddr sin_local;
+					struct sockaddr_storage localsas = { 0, };
+					ast_rtp_instance_get_local_address(instance, &sin_local);
+					memcpy(&localsas, &sin_local, sizeof(struct sockaddr_storage));
+					if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW && sccp_apply_ha(d->ha, &localsas) == AST_SENSE_ALLOW) {
+						directmedia = TRUE;
+					}
+				} else if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW) {			// check remote sin against local device acl (to match netmask)
 					directmedia = TRUE;
+					// ast_channel_defer_dtmf(ast);
 				}
-			} else if (sccp_apply_ha(d->ha, &sas) == AST_SENSE_ALLOW) {					// check remote sin against local device acl (to match netmask)
-				directmedia = TRUE;
-				// ast_channel_defer_dtmf(ast);
+			} else {
+				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk115_update_rtp_peer) failed to get remote ip-address\n", c->currentDeviceId);
+				return -1;
 			}
 		}
 		if (!directmedia) {										// fallback to indirectrtp
+			sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk115_update_rtp_peer) falling back to indirect\n", c->currentDeviceId)
 			ast_rtp_instance_get_local_address(instance, &sin_tmp);
-			memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
-			sccp_session_getOurIP(d->session, &sas, sccp_netsock_is_IPv4(&sas) ? AF_INET : AF_INET6);
+			if (!ast_sockaddr_isnull(&sin_tmp)) {
+				memcpy(&sas, &sin_tmp, sizeof(struct sockaddr_storage));
+				sccp_session_getOurIP(d->session, &sas, sccp_netsock_is_IPv4(&sas) ? AF_INET : AF_INET6);
+			} else {
+				sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk115_update_rtp_peer) failed to get local ip-address\n", c->currentDeviceId);
+				return -1;
+			}
 		}
 
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk115_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s) => directmedia=%s\n", c->currentDeviceId, sccp_netsock_stringify(&sas), S_COR(d->directrtp, "yes", "no"),
-					  sccp_nat2str(d->nat),
-					  S_COR(!nat_active, "yes", "no"), S_COR(directmedia, "yes", "no"), S_COR(directmedia, "yes", "no")
-		    );
+		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_1 "%s: (asterisk115_update_rtp_peer) new remote rtp ip = '%s'\n (d->directrtp: %s && !d->nat: %s && !remote->nat_active: %s && d->acl_allow: %s && !c->conference:%s) => directmedia=%s\n",
+			  c->currentDeviceId, sccp_netsock_stringify(&sas), S_COR(d->directrtp, "yes", "no"),
+			  sccp_nat2str(d->nat),
+			  S_COR(!nat_active, "yes", "no"), S_COR(directmedia, "yes", "no"), S_COR(directmedia, "yes", "no"),
+			  S_COR(!c->conference, "yes", "no")
+		);
 
 		if (rtp) {											// send peer info to phone
 			sccp_rtp_set_peer(c, &c->rtp.audio, &sas);

--- a/src/sccp_actions.c
+++ b/src/sccp_actions.c
@@ -3339,15 +3339,6 @@ void handle_port_response(constSessionPtr s, devicePtr d, constMessagePtr msg_in
 		}
 		
 		if (channel && !sccp_netsock_equals(&sas, &rtp->phone_remote)) {
-			if (d->nat >= SCCP_NAT_ON) {
-				/* Rewrite ip-addres to the outside source address using the phones connection (device->sin) */
-				uint16_t port = sccp_netsock_getPort(&sas);
-				sccp_session_getSas(s, &sas);
-				
-				sccp_netsock_ipv4_mapped(&sas, &sas);
-				sccp_netsock_setPort(&sas, port);
-
-			}
 			sccp_rtp_set_phone(channel, rtp, &sas);
 			//rtp->receiveChannelState = SCCP_RTP_STATUS_PORTSET;
 		}

--- a/src/sccp_indicate.c
+++ b/src/sccp_indicate.c
@@ -298,8 +298,8 @@ void __sccp_indicate(const sccp_device_t * const maybe_device, sccp_channel_t * 
 				d->indicate->connected(d, lineInstance, c->callid, c->calltype, ci);
 				if (c->rtp.audio.receiveChannelState == SCCP_RTP_STATUS_INACTIVE) {
 					sccp_channel_openReceiveChannel(c);
-				} else {
-					sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: Did not reopen an RTP stream as old SCCP state was (%s)\n", d->id, sccp_channelstate2str(c->previousChannelState));
+				} else if (c->rtp.audio.mediaTransmissionState == SCCP_RTP_STATUS_INACTIVE) {
+					sccp_channel_startMediaTransmission(c);
 				}
 				sccp_dev_set_keyset(d, lineInstance, c->callid, KEYMODE_CONNECTED);
 			}
@@ -385,8 +385,8 @@ void __sccp_indicate(const sccp_device_t * const maybe_device, sccp_channel_t * 
 				d->indicate->connected(d, lineInstance, c->callid, c->calltype, ci);
 				if (c->rtp.audio.receiveChannelState == SCCP_RTP_STATUS_INACTIVE) {
 					sccp_channel_openReceiveChannel(c);
-				} else {
-					sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: Did not reopen an RTP stream as old SCCP state was (%s)\n", d->id, sccp_channelstate2str(c->previousChannelState));
+				} else if (c->rtp.audio.mediaTransmissionState == SCCP_RTP_STATUS_INACTIVE) {
+					sccp_channel_startMediaTransmission(c);
 				}
 				sccp_dev_set_keyset(d, lineInstance, c->callid, KEYMODE_CONNCONF);
 			}

--- a/src/sccp_netsock.c
+++ b/src/sccp_netsock.c
@@ -245,6 +245,24 @@ EXIT:
 
 /*!
  * \brief
+ * Compares the port of two sockaddr structures.
+ *
+ * \retval -1 \a a is smaller than \a b
+ * \retval 0 \a a is equal to \a b
+ * \retval 1 \a b is smaller than \a a
+ */
+int sccp_netsock_cmp_port(const struct sockaddr_storage *a, const struct sockaddr_storage *b)
+{
+	uint16_t a_port = sccp_netsock_getPort(a);
+	uint16_t b_port = sccp_netsock_getPort(b);
+
+	sccp_log(DEBUGCAT_HIGH)(VERBOSE_PREFIX_2 "SCCP: sccp_netsock_cmp_port(%d, %d) returning %d\n", a_port, b_port, (a_port < b_port) ? -1 : (a_port == b_port) ? 0 : 1);
+
+	return (a_port < b_port) ? -1 : (a_port == b_port) ? 0 : 1;
+}
+
+/*!
+ * \brief
  * Splits a string into its host and port components
  *
  * \param str       [in] The string to parse. May be modified by writing a NUL at the end of

--- a/src/sccp_netsock.h
+++ b/src/sccp_netsock.h
@@ -49,6 +49,7 @@ SCCP_API size_t __PURE__ SCCP_CALL sccp_netsock_sizeof(const struct sockaddr_sto
 SCCP_API boolean_t __PURE__ SCCP_CALL sccp_netsock_is_mapped_IPv4(const struct sockaddr_storage *sockAddrStorage);
 SCCP_API boolean_t SCCP_CALL sccp_netsock_ipv4_mapped(const struct sockaddr_storage *sockAddrStorage, struct sockaddr_storage *sockAddrStorage_mapped);
 SCCP_API int SCCP_CALL sccp_netsock_cmp_addr(const struct sockaddr_storage *a, const struct sockaddr_storage *b);
+SCCP_API int SCCP_CALL sccp_netsock_cmp_port(const struct sockaddr_storage *a, const struct sockaddr_storage *b);
 SCCP_API int SCCP_CALL sccp_netsock_split_hostport(char *str, char **host, char **port, int flags);
 
 /* helper: easy replacement for inet_ntop for use in sccp_log functions (threadsafe) */

--- a/src/sccp_rtp.c
+++ b/src/sccp_rtp.c
@@ -118,7 +118,7 @@ boolean_t sccp_rtp_createServer(constDevicePtr d, channelPtr c, sccp_rtp_type_t 
 			break;
 #endif
 		default:
-			pbx_log(LOG_ERROR, "%s: (sccp_rtp_createRTPServer) unknown/unhandled rtp type, cancelling\n", c->designator);
+			pbx_log(LOG_ERROR, "%s: (createRTPServer) unknown/unhandled rtp type, cancelling\n", c->designator);
 			return FALSE;
 	}
 
@@ -154,7 +154,7 @@ boolean_t sccp_rtp_createServer(constDevicePtr d, channelPtr c, sccp_rtp_type_t 
 	char buf[NI_MAXHOST + NI_MAXSERV];
 	sccp_copy_string(buf, sccp_netsock_stringify(phone_remote), sizeof(buf));
 	boolean_t isMappedIPv4 = sccp_netsock_ipv4_mapped(phone_remote, phone_remote);
-	sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: (createAudioServer) updated phone %s destination to : %s, family:%s, mapped: %s\n", c->designator, sccp_rtp_type2str(type), buf, sccp_netsock_is_IPv4(phone_remote) ? "IPv4" : "IPv6", isMappedIPv4 ? "True" : "False");
+	sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: (createRTPServer) updated phone %s destination to : %s, family:%s, mapped: %s\n", c->designator, sccp_rtp_type2str(type), buf, sccp_netsock_is_IPv4(phone_remote) ? "IPv4" : "IPv6", isMappedIPv4 ? "True" : "False");
 
 	return rtpResult;
 }
@@ -169,6 +169,7 @@ int sccp_rtp_requestRTPPorts(constDevicePtr device, channelPtr channel)
 	sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: (requestRTPPort) request rtp port from phone\n", device->id);
 	device->protocol->sendPortRequest(device, channel, SKINNY_MEDIA_TRANSPORT_TYPE_RTP, SKINNY_MEDIA_TYPE_AUDIO);
 
+/*
 #ifdef CS_SCCP_VIDEO
  	if (sccp_device_isVideoSupported(device) && channel->videomode != SCCP_VIDEO_MODE_OFF) {
 		sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: (requestRTPPort) request vrtp port from phone\n", device->id);
@@ -177,6 +178,7 @@ int sccp_rtp_requestRTPPorts(constDevicePtr device, channelPtr channel)
 		}
 	}
 #endif
+*/
 	return 1;
 }
 

--- a/src/sccp_rtp.c
+++ b/src/sccp_rtp.c
@@ -277,15 +277,7 @@ void sccp_rtp_set_phone(constChannelPtr c, sccp_rtp_t * const rtp, struct sockad
 	AUTO_RELEASE(sccp_device_t, device , sccp_channel_getDevice(c));
 
 	if (device) {
-
 		/* check if we have new infos */
-		/*! \todo if we enable this, we get an audio issue when resume on the same device, so we need to force asterisk to update -MC */
-		/*
-		if (sccp_netsock_equals(new_peer, &c->rtp.audio.phone)) {
-			sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_2 "%s: (sccp_rtp_set_phone) remote information are equal to the current one, ignore change\n", c->currentDeviceId);
-			//return;
-		}
-		*/
 		char peerIpStr[NI_MAXHOST + NI_MAXSERV];
 		char remoteIpStr[NI_MAXHOST + NI_MAXSERV];
 		char phoneIpStr[NI_MAXHOST + NI_MAXSERV];
@@ -299,19 +291,18 @@ void sccp_rtp_set_phone(constChannelPtr c, sccp_rtp_t * const rtp, struct sockad
 		}
 
 		memcpy(&rtp->phone, new_peer, sizeof(rtp->phone));
-
-		//update pbx
-		if (iPbx.rtp_setPhoneAddress) {
+		if (iPbx.rtp_setPhoneAddress && rtp->instance) {
 			iPbx.rtp_setPhoneAddress(rtp, new_peer, device->nat >= SCCP_NAT_ON ? 1 : 0);
+
+			sccp_copy_string(remoteIpStr, sccp_netsock_stringify(&rtp->phone_remote), sizeof(remoteIpStr));
+			sccp_copy_string(phoneIpStr, sccp_netsock_stringify(&rtp->phone), sizeof(phoneIpStr));
+			if (device->nat >= SCCP_NAT_ON) {
+				sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: Tell %s  to send RTP/UDP media from %s to %s (NAT:%s)\n", DEV_ID_LOG(device), device->directrtp ? "Peer" : "PBX ", remoteIpStr, phoneIpStr, peerIpStr);
+			} else {
+				sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: Tell %s  to send RTP/UDP media from %s to %s (NoNat)\n", DEV_ID_LOG(device), device->directrtp ? "Peer" : "PBX ", remoteIpStr, phoneIpStr);
+			}
 		}
 
-		sccp_copy_string(remoteIpStr, sccp_netsock_stringify(&rtp->phone_remote), sizeof(remoteIpStr));
-		sccp_copy_string(phoneIpStr, sccp_netsock_stringify(&rtp->phone), sizeof(phoneIpStr));
-		if (device->nat >= SCCP_NAT_ON) {
-			sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: Tell PBX   to send RTP/UDP media from %s to %s (NAT:%s)\n", DEV_ID_LOG(device), remoteIpStr, phoneIpStr, peerIpStr);
-		} else {
-			sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: Tell PBX   to send RTP/UDP media from %s to %s (NoNat)\n", DEV_ID_LOG(device), remoteIpStr, phoneIpStr);
-		}
 	}
 }
 

--- a/src/sccp_utils.c
+++ b/src/sccp_utils.c
@@ -693,7 +693,7 @@ boolean_t __PURE__ sccp_util_matchSubscriptionId(const sccp_channel_t * channel,
  */
 gcc_inline boolean_t sccp_netsock_equals(const struct sockaddr_storage * const s0, const struct sockaddr_storage *const s1)
 {
-	if (s0->ss_family == s1->ss_family && sccp_netsock_cmp_addr(s0, s1) == 0 ) {
+	if ((s0->ss_family == s1->ss_family && sccp_netsock_cmp_addr(s0, s1) == 0) && sccp_netsock_cmp_port(s0, s1) == 0) {
 		return TRUE;
 	} 
 


### PR DESCRIPTION
Fix: check the result from ast_rtp_instance_get_remote_address to see if we got an address
Fix: check if ast_rtp_instance_get_remote_address / ast_rtp_instance_get_local_address return is not null
Fix: Apply netsock_cmp_port patch from Salvador (sccp_rtp_set_phone).
Fix: Re-enable sccp_handle_port_reponse to set the report port early (handle_port_response)
Enh: Add debug log entry about conference in update_rtp_peer
Enh: check if active conference when processing sccp_rtp_set_phone
Enh: remove incorrect debug statement
Enh: Update sccp_rtp_set_phone, show Peer instead of PBX when dealing with directrtp
Fix: Move AST_CONTROL_UNHOLD from sccp_channel_resume to openReceiveChannelAck to fix the serial ordering
    (required for asterisk-13 which runs 'update_rtp_peer' in parallel, causing a race)
    Changes required for >asterisk-12:
    Local
    1. OpenReceive
    2. OpenReceiveAck
    3. setRtpPhone to newly acquired ip-address
    4. startMediaTransmission
    5. Indicate AST_CONTROL_UNHOLD -> kicks peer into action
    Peer
    6. Peer will re-bridge
    7. Which will then use the newly acquired ip-address of it's remote side (our local side)
    This used to work correction, when we only stopped media transmission, but did not tear down the openreceive channel. This did however
    cause issues on older phone, which only support 1 active RTP channel.

Fixes #394
Fixes #391
Fixes #405 

Inform: @Developers
