### PR TITLE
Conference causing segfault when using asterisk-13 or higher

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
 
-
                     GNU GENERAL PUBLIC LICENSE
                      Version 1, February 1989
 

--- a/src/pbx_impl/ast106/ast106.c
+++ b/src/pbx_impl/ast106/ast106.c
@@ -1939,7 +1939,7 @@ static int sccp_wrapper_asterisk16_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_R
 		} else if (vrtp) {
 			sccp_rtp_set_peer(c, &c->rtp.video, &sas);
 			c->rtp.video.directMedia = directmedia;
-			//} else {
+		} else {
 			//sccp_rtp_set_peer(c, &c->rtp.text, &sas);
 			//c->rtp.text.directMedia = directmedia;
 		}

--- a/src/pbx_impl/ast108/ast108.c
+++ b/src/pbx_impl/ast108/ast108.c
@@ -1897,7 +1897,6 @@ static int sccp_wrapper_asterisk18_update_rtp_peer(PBX_CHANNEL_TYPE * ast, PBX_R
 
 		if (rtp) {											// send peer info to phone
 			sccp_rtp_set_peer(c, &c->rtp.audio, &sas);
-
 			c->rtp.audio.directMedia = directmedia;
 		} else if (vrtp) {
 			sccp_rtp_set_peer(c, &c->rtp.video, &sas);

--- a/src/pbx_impl/ast113/ast113.c
+++ b/src/pbx_impl/ast113/ast113.c
@@ -1,4 +1,4 @@
-/*!
+/*
  * \file        ast113.c
  * \brief       SCCP PBX Asterisk Wrapper Class
  * \author      Marcello Ceshia
@@ -94,6 +94,7 @@ static boolean_t sccp_wrapper_asterisk113_setReadFormat(constChannelPtr channel,
 PBX_CHANNEL_TYPE *sccp_wrapper_asterisk113_findPickupChannelByExtenLocked(PBX_CHANNEL_TYPE * chan, const char *exten, const char *context);
 PBX_CHANNEL_TYPE *sccp_wrapper_asterisk113_findPickupChannelByGroupLocked(PBX_CHANNEL_TYPE * chan);
 
+/*
 static inline skinny_codec_t sccp_asterisk113_getSkinnyFormatSingle(struct ast_format_cap *ast_format_capability)
 {
 	uint formatPosition;
@@ -113,7 +114,7 @@ static inline skinny_codec_t sccp_asterisk113_getSkinnyFormatSingle(struct ast_f
 
 	return codec;
 }
-
+*/
 static uint8_t sccp_asterisk113_getSkinnyFormatMultiple(struct ast_format_cap *ast_format_capability, skinny_codec_t codec[], int length)
 {
 	// struct ast_format tmp_fmt;
@@ -123,7 +124,7 @@ static uint8_t sccp_asterisk113_getSkinnyFormatMultiple(struct ast_format_cap *a
 	struct ast_str *codec_buf = ast_str_alloca(64);
 	struct ast_format *format;
 
-	sccp_log(DEBUGCAT_RTP)(VERBOSE_PREFIX_3 "SCCP: (getSkinnyFormatSingle) caps %s\n", ast_format_cap_get_names(ast_format_capability,&codec_buf));
+	sccp_log(DEBUGCAT_CODEC)(VERBOSE_PREFIX_3 "SCCP: (getSkinnyFormatMultiple) caps %s\n", ast_format_cap_get_names(ast_format_capability,&codec_buf));
 
 	for (formatPosition = 0; formatPosition < ast_format_cap_count(ast_format_capability); ++formatPosition) {
 		format = ast_format_cap_get_format(ast_format_capability, formatPosition);
@@ -377,8 +378,6 @@ static int sccp_wrapper_asterisk113_devicestate(const char *data)
 	sccp_log((DEBUGCAT_HINT)) (VERBOSE_PREFIX_4 "SCCP: (sccp_asterisk_devicestate) PBX requests state for '%s' - state %s\n", lineName, ast_devstate2str(res));
 	return res;
 }
-
-static boolean_t sccp_wrapper_asterisk113_setReadFormat(constChannelPtr channel, skinny_codec_t codec);
 
 #define RTP_NEW_SOURCE(_c,_log) 								\
 	if(c->rtp.audio.instance) { 										\
@@ -907,18 +906,26 @@ static int sccp_wrapper_asterisk113_setNativeAudioFormats(constChannelPtr channe
 		return 0;
 	}
 
-	length = 1;												//set only one codec
-	ast_debug(10, "%s: set native Formats length: %d\n", (char *) channel->currentDeviceId, length);
-
-	ast_format_cap_remove_by_type(ast_channel_nativeformats(channel->owner), AST_MEDIA_TYPE_AUDIO);
+	//length = 1;												//set only one codec
+	//ast_debug(10, "%s: set native Formats length: %d\n", (char *) channel->currentDeviceId, length);
+	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!caps) {
+		return FALSE;
+	}
+	ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(channel->owner), AST_MEDIA_TYPE_UNKNOWN);
+	ast_format_cap_remove_by_type(caps, AST_MEDIA_TYPE_AUDIO);
 	//pbx_format_cap_append_skinny(ast_channel_nativeformats(channel->owner), codec);			// if length != 1
 	for (i = 0; i < length; i++) {
-		struct ast_format *format = sccp_asterisk113_skinny2ast_format(codec[i]);
+		struct ast_format *format = sccp_asterisk113_skinny2ast_format(codec[1]);
 		if (format != ast_format_none) {
 			unsigned int framing = ast_format_get_default_ms(format);
-			ast_format_cap_append(ast_channel_nativeformats(channel->owner), format, framing);
+			ast_format_cap_append(caps, format, framing);
 		}
 	}
+	ast_channel_lock(channel->owner);
+	ast_channel_nativeformats_set(channel->owner, caps);
+	ast_channel_unlock(channel->owner);
+	ao2_cleanup(caps);
 
 	return 1;
 }
@@ -928,15 +935,26 @@ static int sccp_wrapper_asterisk113_setNativeVideoFormats(constChannelPtr channe
 	int i;
 	int length = 1;
 
+	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!caps) {
+		return FALSE;
+	}
+	ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(channel->owner), AST_MEDIA_TYPE_UNKNOWN);
+	ast_format_cap_remove_by_type(caps, AST_MEDIA_TYPE_VIDEO);
 	for (i = 0; i < length; i++) {
 		struct ast_format *format = sccp_asterisk113_skinny2ast_format(codec);
 		if (format != ast_format_none) {
 			unsigned int framing = ast_format_get_default_ms(format);
-			ast_format_cap_append(ast_channel_nativeformats(channel->owner), format, framing);
+			ast_format_cap_append(caps, format, framing);
 		}
 	}
+	ast_channel_lock(channel->owner);
+	ast_channel_nativeformats_set(channel->owner, caps);
+	ast_channel_unlock(channel->owner);
+	ao2_cleanup(caps);
 	return 1;
 }
+
 
 static void sccp_wrapper_asterisk113_removeTimingFD(PBX_CHANNEL_TYPE *ast)
 {
@@ -1016,6 +1034,11 @@ static boolean_t sccp_wrapper_asterisk113_allocPBXChannel(sccp_channel_t * chann
 		return FALSE;
 	}
 
+	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!caps) {
+		return FALSE;
+	}
+
 	if (ids) {
 		assignedids = ids;
 	}
@@ -1024,6 +1047,7 @@ static boolean_t sccp_wrapper_asterisk113_allocPBXChannel(sccp_channel_t * chann
 	pbxDstChannel = ast_channel_alloc(0, AST_STATE_DOWN, line->cid_num, line->cid_name, line->accountcode, line->name, line->context, assignedids, pbxSrcChannel, line->amaflags, "%s", channel->designator);
 	if (pbxDstChannel == NULL) {
 		pbx_log(LOG_ERROR, "SCCP: (allocPBXChannel) ast_channel_alloc failed\n");
+		ao2_cleanup(caps);
 		return FALSE;
 	}
 	ast_channel_stage_snapshot(pbxDstChannel);
@@ -1031,14 +1055,8 @@ static boolean_t sccp_wrapper_asterisk113_allocPBXChannel(sccp_channel_t * chann
 
 	ast_channel_tech_set(pbxDstChannel, &sccp_tech);
 	ast_channel_tech_pvt_set(pbxDstChannel, sccp_channel_retain(channel));
-	//ast_channel_tech_pvt_set(pbxDstChannel, channel);
 
 	/* Copy Codec from SrcChannel */
-	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
-	if (!caps) {
-		return NULL;
-	}
-
 	if (pbxSrcChannel && ast_format_cap_count(ast_channel_nativeformats(pbxSrcChannel)) > 0) {
 		ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(pbxSrcChannel), AST_MEDIA_TYPE_UNKNOWN);
 	} else if (line && channel) {
@@ -1048,11 +1066,8 @@ static boolean_t sccp_wrapper_asterisk113_allocPBXChannel(sccp_channel_t * chann
 #endif		
 	}
 	ast_channel_nativeformats_set(pbxDstChannel, caps);
-	ao2_ref(caps, -1);
-	
-	struct ast_format *tmpfmt = ast_format_cap_get_format(ast_channel_nativeformats(pbxDstChannel), 0);
-	//struct ast_str *codec_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
-	//pbx_log(LOG_NOTICE, "allocPBXChannel: tmp->nativeformats=%s fmt=%s\n", ast_format_cap_get_names(ast_channel_nativeformats(pbxDstChannel), &codec_buf), ast_format_get_name(tmpfmt));
+	struct ast_format *tmpfmt = ast_format_cap_get_format(caps, 0);
+	ao2_cleanup(caps);
 	ast_channel_set_writeformat(pbxDstChannel, tmpfmt);
 	ast_channel_set_rawwriteformat(pbxDstChannel, tmpfmt);
 	ast_channel_set_readformat(pbxDstChannel, tmpfmt);
@@ -1141,7 +1156,7 @@ static boolean_t sccp_wrapper_asterisk113_masqueradeHelper(PBX_CHANNEL_TYPE * pb
 		ast_hangup(pbxTmpChannel);
 	}
 	pbx_log(LOG_NOTICE, "SCCP: (masqueradeHelper) remove reference from pbxTmpChannel: %s\n", ast_channel_name(pbxTmpChannel));
-	ast_channel_unref(pbxTmpChannel);
+	pbx_channel_unref(pbxTmpChannel);
 	return res;
 }
 
@@ -1150,7 +1165,7 @@ static boolean_t sccp_wrapper_asterisk113_allocTempPBXChannel(PBX_CHANNEL_TYPE *
 	PBX_CHANNEL_TYPE *pbxDstChannel = NULL;
 	struct ast_assigned_ids assignedids = {NULL, NULL};
 
-	struct ast_format *ast_format;
+	struct ast_format *tmpfmt;
 	unsigned int framing;
 
 	if (!pbxSrcChannel) {
@@ -1167,31 +1182,41 @@ static boolean_t sccp_wrapper_asterisk113_allocTempPBXChannel(PBX_CHANNEL_TYPE *
 		assignedids.uniqueid2 = uniqueid2;
 	}
 */
+	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!caps) {
+		return FALSE;
+	}
 
 	ast_channel_lock(pbxSrcChannel);
 	pbxDstChannel = ast_channel_alloc(0, AST_STATE_DOWN, 0, 0, ast_channel_accountcode(pbxSrcChannel), pbx_channel_exten(pbxSrcChannel), pbx_channel_context(pbxSrcChannel), &assignedids, pbxSrcChannel, ast_channel_amaflags(pbxSrcChannel), "%s-TMP", ast_channel_name(pbxSrcChannel));
 	if (pbxDstChannel == NULL) {
 		pbx_log(LOG_ERROR, "SCCP: (alloc_conferenceTempPBXChannel) ast_channel_alloc failed\n");
+		ast_channel_unlock(pbxSrcChannel);
+		ao2_cleanup(caps);
 		return FALSE;
 	}
 
 	ast_channel_stage_snapshot(pbxDstChannel);
-	// ast_channel_tech_set(pbxDstChannel, &sccp_tech);
 	ast_channel_tech_set(pbxDstChannel, &null_tech);							// USE null_tech to prevent fixup issues. Channel is only used to masquerade a channel out of a running bridge.
 
-	// if (ast_format_cap_is_empty(pbx_channel_nativeformats(pbxSrcChannel))) {
+	/* Copy Codec from SrcChannel */
 	if (ast_format_cap_count(pbx_channel_nativeformats(pbxSrcChannel)) == 0) {
-		ast_format = ast_format_alaw;
-		ao2_ref(ast_format, +1);
+		tmpfmt = ast_format_alaw;
+		//tmpfmt = ast_format_slin;
+		ao2_ref(tmpfmt, +1);
 	} else {
-		ast_format = ast_format_cap_get_best_by_type(pbx_channel_nativeformats(pbxSrcChannel), AST_MEDIA_TYPE_AUDIO);
+		tmpfmt = ast_format_cap_get_best_by_type(pbx_channel_nativeformats(pbxSrcChannel), AST_MEDIA_TYPE_AUDIO);
 	}
-	framing = ast_format_get_default_ms(ast_format);
-	ast_format_cap_remove_by_type(ast_channel_nativeformats(pbxDstChannel), AST_MEDIA_TYPE_AUDIO);
-	ast_format_cap_append(ast_channel_nativeformats(pbxDstChannel), ast_format, framing);
-	ast_set_read_format(pbxDstChannel, ast_format);
-	ast_set_write_format(pbxDstChannel, ast_format);
-	ao2_ref(ast_format, -1);
+	framing = ast_format_get_default_ms(tmpfmt);
+	ast_format_cap_append(caps, tmpfmt, framing);
+	ast_channel_nativeformats_set(pbxDstChannel, caps);
+	ao2_cleanup(caps);
+	ast_channel_set_writeformat(pbxDstChannel, tmpfmt);
+	ast_channel_set_rawwriteformat(pbxDstChannel, tmpfmt);
+	ast_channel_set_readformat(pbxDstChannel, tmpfmt);
+	ast_channel_set_rawreadformat(pbxDstChannel, tmpfmt);
+	ao2_ref(tmpfmt, -1);
+	/* EndCodec */
 
 	ast_channel_context_set(pbxDstChannel, ast_channel_context(pbxSrcChannel));
 	ast_channel_exten_set(pbxDstChannel, ast_channel_exten(pbxSrcChannel));
@@ -1202,7 +1227,8 @@ static boolean_t sccp_wrapper_asterisk113_allocTempPBXChannel(PBX_CHANNEL_TYPE *
 	ast_channel_unlock(pbxSrcChannel);
 	ast_channel_unlock(pbxDstChannel);
 
-	(*_pbxDstChannel) = pbx_channel_ref(pbxDstChannel);
+	(*_pbxDstChannel) = pbxDstChannel;
+
 	return TRUE;
 }
 
@@ -1356,7 +1382,8 @@ static uint8_t sccp_wrapper_asterisk113_get_payloadType(const struct sccp_rtp *r
 {
 	struct ast_format *astCodec = sccp_asterisk113_skinny2ast_format(codec);
 	if (astCodec != ast_format_none) {
-		return ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(rtp->instance), skinny_codec2pbx_codec(codec), astCodec, 0);
+		//return ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(rtp->instance), skinny_codec2pbx_codec(codec), astCodec, 0);
+		return ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(rtp->instance), 0, astCodec, 0);
 	}
 	return 0;
 }
@@ -1431,18 +1458,21 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk113_request(const char *type, stru
 	struct ast_str *codec_buf = ast_str_alloca(64);
 #if !defined(CS_AST_CHANNEL_CALLID_TYPEDEF)
 	struct ast_callid *callid = NULL;
-#else
+#else	
 	ast_callid callid = 0;
 #endif
-	skinny_codec_t audioCapabilities[SKINNY_MAX_CAPABILITIES];
-	skinny_codec_t videoCapabilities[SKINNY_MAX_CAPABILITIES];
+
+	skinny_codec_t audioCapabilities[SKINNY_MAX_CAPABILITIES] = {0};
+	skinny_codec_t videoCapabilities[SKINNY_MAX_CAPABILITIES] = {0};
 
 	memset(&audioCapabilities, 0, sizeof(audioCapabilities));
 	memset(&videoCapabilities, 0, sizeof(videoCapabilities));
 
 	//! \todo parse request
 	char *lineName;
-	skinny_codec_t codec = SKINNY_CODEC_G711_ULAW_64K;
+	skinny_codec_t audio_codec = SKINNY_CODEC_G722_64K;
+	skinny_codec_t video_codec = SKINNY_CODEC_H264;
+
 	sccp_autoanswer_t autoanswer_type = SCCP_AUTOANSWER_NONE;
 	uint8_t autoanswer_cause = AST_CAUSE_NOTDEFINED;
 	skinny_ringtype_t ringermode = GLOB(ringtype);
@@ -1486,16 +1516,25 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk113_request(const char *type, stru
 		*cause = autoanswer_cause;
 	}
 
-	/** getting remote capabilities */
-	char cap_buf[512];
+	/** get requested format */
+	if ( (audio_codec = pbx_codec2skinny_codec(ast_format_compatibility_format2bitfield(ast_format_cap_get_best_by_type(cap, AST_MEDIA_TYPE_AUDIO)))) == SKINNY_CODEC_NONE) {
+		pbx_log(LOG_NOTICE, "Could not match audio codec, Falling back to ULAW\n");
+		audio_codec = SKINNY_CODEC_G722_64K;
+	}
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "SCCP: requested Audio Codec in Skinny Format: %s\n", codec2str(audio_codec));
+#ifdef CS_SCCP_VIDEO
+	if ( (video_codec = pbx_codec2skinny_codec(ast_format_compatibility_format2bitfield(ast_format_cap_get_best_by_type(cap, AST_MEDIA_TYPE_VIDEO)))) == SKINNY_CODEC_NONE) {
+		pbx_log(LOG_NOTICE, "Could not match video codec. No Video\n");
+		video_codec = 0;
+	}
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "SCCP: requested Video Codec in Skinny Format: %s\n", codec2str(video_codec));
+#endif
 
-	/* audio capabilities */
+	/** getting remote capabilities */
 	if (requestor) {
 		AUTO_RELEASE(sccp_channel_t, remoteSccpChannel , get_sccp_channel_from_pbx_channel(requestor));
 		if (remoteSccpChannel) {
-			uint8_t x, y, z;
-
-			z = 0;
+			uint8_t x, y, z = 0;
 			/* shrink audioCapabilities to remote preferred/capable format */
 			for (x = 0; x < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->preferences.audio[x] != 0; x++) {
 				for (y = 0; y < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->capabilities.audio[y] != 0; y++) {
@@ -1506,32 +1545,48 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk113_request(const char *type, stru
 				}
 			}
 		} else {
-			if (!sccp_asterisk113_getSkinnyFormatMultiple(ast_channel_nativeformats(requestor), audioCapabilities, ARRAY_LEN(audioCapabilities))) {
+			struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+			ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(requestor), AST_MEDIA_TYPE_AUDIO);
+			if (!sccp_asterisk113_getSkinnyFormatMultiple(caps, audioCapabilities, ARRAY_LEN(audioCapabilities))) {
 				pbx_log(LOG_NOTICE, "SCCP: remote native format is not compatible with any skinny format. Transcoding required\n");
 				audioCapabilities[0] = SKINNY_CODEC_WIDEBAND_256K;
 			}
+			ao2_cleanup(caps);
 		}
-
-		/* video capabilities */
-		sccp_asterisk113_getSkinnyFormatMultiple(ast_channel_nativeformats(requestor), videoCapabilities, ARRAY_LEN(videoCapabilities));	//replace AUDIO_MASK with AST_FORMAT_TYPE_AUDIO check
+#ifdef CS_SCCP_VIDEO
+		if (remoteSccpChannel) {
+			uint8_t x, y, z = 0;
+			for (x = 0; x < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->preferences.video[x] != 0; x++) {
+				for (y = 0; y < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->capabilities.video[y] != 0; y++) {
+					if (remoteSccpChannel->preferences.video[x] == remoteSccpChannel->capabilities.video[y]) {
+						videoCapabilities[z++] = remoteSccpChannel->preferences.video[x];
+						break;
+					}
+				}
+			}
+		} else {
+			struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+			ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(requestor), AST_MEDIA_TYPE_VIDEO);
+			sccp_asterisk113_getSkinnyFormatMultiple(caps, videoCapabilities, ARRAY_LEN(videoCapabilities));
+			ao2_cleanup(caps);
+		}
+#endif
+	} else {
+		audioCapabilities[0] = audio_codec;
+		videoCapabilities[0] = video_codec;
 	}
-
+	char cap_buf[512];
 	sccp_codec_multiple2str(cap_buf, sizeof(cap_buf) - 1, audioCapabilities, ARRAY_LEN(audioCapabilities));
-	// sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote audio caps: %s\n", cap_buf);
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote audio caps: %s\n", cap_buf);
 
 	sccp_codec_multiple2str(cap_buf, sizeof(cap_buf) - 1, videoCapabilities, ARRAY_LEN(videoCapabilities));
-	// sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote video caps: %s\n", cap_buf);
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote video caps: %s\n", cap_buf);
 	/** done */
-
-	/** get requested format */
-	//codec = pbx_codec2skinny_codec(ast_format_compatibility_format2bitfield(format));
-	codec = sccp_asterisk113_getSkinnyFormatSingle(cap);
-	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "SCCP: requestedCodec in Skinny Format: %d\n", codec);
 
 	int callid_created = ast_callid_threadstorage_auto(&callid);
 
 	AUTO_RELEASE(sccp_channel_t, channel , NULL);
-	requestStatus = sccp_requestChannel(lineName, codec, audioCapabilities, ARRAY_LEN(audioCapabilities), autoanswer_type, autoanswer_cause, ringermode, &channel);
+	requestStatus = sccp_requestChannel(lineName, audio_codec, audioCapabilities, ARRAY_LEN(audioCapabilities), autoanswer_type, autoanswer_cause, ringermode, &channel);
 	switch (requestStatus) {
 		case SCCP_REQUEST_STATUS_SUCCESS:								// everything is fine
 			break;
@@ -1552,6 +1607,14 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk113_request(const char *type, stru
 			*cause = AST_CAUSE_UNALLOCATED;
 			goto EXITFUNC;
 	}
+#ifdef CS_SCCP_VIDEO
+	memset(&channel->remoteCapabilities.video, 0, sizeof(channel->remoteCapabilities.video));
+	if (videoCapabilities[0] != SKINNY_CODEC_NONE) {
+		memcpy(channel->remoteCapabilities.video, videoCapabilities, ARRAY_LEN(videoCapabilities));
+	} else if (video_codec) {
+		channel->remoteCapabilities.video[0] = video_codec;
+	}
+#endif
 	
 	if (!sccp_pbx_channel_allocate(channel, assignedids, requestor)) {
 		//! \todo handle error in more detail, cleanup sccp channel
@@ -1584,22 +1647,6 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk113_request(const char *type, stru
 				SCCP_CALLINFO_ORIG_CALLEDPARTY_NUMBER, ast_channel_redirecting((PBX_CHANNEL_TYPE *) requestor)->orig.number.str,
 				SCCP_CALLINFO_KEY_SENTINEL);
 	}
-
-	/** workaround for asterisk console log flooded
-	 channel.c:5080 ast_write: Codec mismatch on channel SCCP/xxx-0000002d setting write format to g722 from unknown native formats (nothing)
-	*/
-	if (!channel->capabilities.audio[0]) {
-		skinny_codec_t codecs[] = { SKINNY_CODEC_WIDEBAND_256K };
-		sccp_wrapper_asterisk113_setNativeAudioFormats(channel, codecs, 1);
-		sccp_wrapper_asterisk113_setReadFormat(channel, SKINNY_CODEC_WIDEBAND_256K);
-		sccp_wrapper_asterisk113_setWriteFormat(channel, SKINNY_CODEC_WIDEBAND_256K);
-	}
-	
-	/* get remote codecs from channel driver */
-	//ast_rtp_instance_get_codecs(c->rtp.adio.rtp);
-	//ast_rtp_instance_get_codecs(c->rtp.video.instance);
-	/** done */
-
 EXITFUNC:
 	if (channel) {
 		result_ast_channel = channel->owner;
@@ -1607,10 +1654,6 @@ EXITFUNC:
 			ast_channel_callid_set(result_ast_channel, callid);
 		}
 		channel->pbx_callid_created = callid_created;
-	} else if (callid) {
-#if !defined(CS_AST_CHANNEL_CALLID_TYPEDEF)
-		ast_callid_unref(callid);
-#endif
 	}
 	return result_ast_channel;
 }
@@ -1702,14 +1745,14 @@ static int sccp_wrapper_asterisk113_fixup(PBX_CHANNEL_TYPE * oldchan, PBX_CHANNE
 				// set channel requestHangup to use ast_hangup (as it will not be part of __ast_pbx_run anymore, upon returning from masquerade)
 				c->hangupRequest = sccp_wrapper_asterisk_requestHangup;
 			}
-			// c->owner = ast_channel_ref(newchan);
-			// ast_channel_unref(oldchan);
 			sccp_wrapper_asterisk113_setOwner(c, newchan);
 			//! \todo force update of rtp peer for directrtp
 			// sccp_wrapper_asterisk113_update_rtp_peer(newchan, NULL, NULL, 0, 0, 0);
 
 			//! \todo update remote capabilities after fixup
 
+			struct ast_str *codec_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
+			pbx_log(LOG_NOTICE, "Fixup: nativeformats=%s\n", ast_format_cap_get_names(ast_channel_nativeformats(newchan), &codec_buf));
 		}
 	} else {
 		pbx_log(LOG_WARNING, "sccp_pbx_fixup(old: %s(%p), new: %s(%p)). no SCCP channel to fix\n", pbx_channel_name(oldchan), (void *) oldchan, pbx_channel_name(newchan), (void *) newchan);
@@ -2221,6 +2264,7 @@ static boolean_t sccp_wrapper_asterisk113_createRtpInstance(constDevicePtr d, co
 		// this prevent a warning about unknown codec, when rtp traffic starts */
 		ast_queue_frame(c->owner, &ast_null_frame);
 	}
+	ast_rtp_codecs_set_framing(ast_rtp_instance_get_codecs(instance), ast_format_cap_get_framing(ast_channel_nativeformats(c->owner)));
 
 	return TRUE;
 }
@@ -2294,23 +2338,10 @@ static boolean_t sccp_wrapper_asterisk113_setWriteFormat(constChannelPtr channel
 	if (!channel) {
 		return FALSE;
 	}
+
+	//sccp_log(DEBUGCAT_CODEC)(VERBOSE_PREFIX_1 "%s: setWriteFormat:%s\n", channel->designator, codec2str(codec));
 	struct ast_format *ast_format = sccp_asterisk113_skinny2ast_format(codec);
-	if (ast_format != ast_format_none) {
-		struct ast_format_cap *cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
-		if (!cap) {
-			ao2_cleanup(cap);
-			return FALSE;
-		}
-
-		unsigned int framing = ast_format_get_default_ms(ast_format);
-		ast_format_cap_append(cap, ast_format, framing);
-		ast_set_write_format_from_cap(channel->owner, cap);
-
-		ao2_ref(cap, -1);
-		cap = NULL;
-	} else {
-		return FALSE;
-	}
+	ast_set_write_format(channel->owner, ast_format);
 
 	if (NULL != channel->rtp.audio.instance) {
 		ast_rtp_instance_set_write_format(channel->rtp.audio.instance, ast_format);
@@ -2323,24 +2354,9 @@ static boolean_t sccp_wrapper_asterisk113_setReadFormat(constChannelPtr channel,
 	if (!channel) {
 		return FALSE;
 	}
-
+	//sccp_log(DEBUGCAT_CODEC)(VERBOSE_PREFIX_1 "%s: setReadFormat:%s\n", channel->designator, codec2str(codec));
 	struct ast_format *ast_format = sccp_asterisk113_skinny2ast_format(codec);
-	if (ast_format != ast_format_none) {
-		struct ast_format_cap *cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
-		if (!cap) {
-			ao2_cleanup(cap);
-			return FALSE;
-		}
-
-		unsigned int framing = ast_format_get_default_ms(ast_format);
-		ast_format_cap_append(cap, ast_format, framing);
-		ast_set_read_format_from_cap(channel->owner, cap);
-
-		ao2_ref(cap, -1);
-		cap = NULL;
-	} else {
-		return FALSE;
-	}
+	ast_set_read_format(channel->owner, ast_format);
 
 	if (NULL != channel->rtp.audio.instance) {
 		ast_rtp_instance_set_read_format(channel->rtp.audio.instance, ast_format);

--- a/src/pbx_impl/ast113/ast113.c
+++ b/src/pbx_impl/ast113/ast113.c
@@ -1141,7 +1141,7 @@ static boolean_t sccp_wrapper_asterisk113_masqueradeHelper(PBX_CHANNEL_TYPE * pb
 		ast_hangup(pbxTmpChannel);
 	}
 	pbx_log(LOG_NOTICE, "SCCP: (masqueradeHelper) remove reference from pbxTmpChannel: %s\n", ast_channel_name(pbxTmpChannel));
-	pbxTmpChannel = ast_channel_unref(pbxTmpChannel);
+	ast_channel_unref(pbxTmpChannel);
 	return res;
 }
 

--- a/src/pbx_impl/ast114/ast114.c
+++ b/src/pbx_impl/ast114/ast114.c
@@ -1449,7 +1449,11 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk114_request(const char *type, stru
 	sccp_channel_request_status_t requestStatus;
 	PBX_CHANNEL_TYPE *result_ast_channel = NULL;
 	struct ast_str *codec_buf = ast_str_alloca(64);
+#if !defined(CS_AST_CHANNEL_CALLID_TYPEDEF)
+	struct ast_callid *callid = NULL;
+#else	
 	ast_callid callid = 0;
+#endif
 
 	skinny_codec_t audioCapabilities[SKINNY_MAX_CAPABILITIES] = {0};
 	skinny_codec_t videoCapabilities[SKINNY_MAX_CAPABILITIES] = {0};

--- a/src/pbx_impl/ast114/ast114.c
+++ b/src/pbx_impl/ast114/ast114.c
@@ -376,8 +376,6 @@ static int sccp_wrapper_asterisk114_devicestate(const char *data)
 	return res;
 }
 
-static boolean_t sccp_wrapper_asterisk114_setReadFormat(constChannelPtr channel, skinny_codec_t codec);
-
 #define RTP_NEW_SOURCE(_c,_log) 								\
 	if(c->rtp.audio.instance) { 										\
 		ast_rtp_new_source(c->rtp.audio.instance); 							\
@@ -906,19 +904,26 @@ static int sccp_wrapper_asterisk114_setNativeAudioFormats(constChannelPtr channe
 		return 0;
 	}
 
-	length = 1;												//set only one codec
-
-	ast_debug(10, "%s: set native Formats length: %d\n", (char *) channel->currentDeviceId, length);
-
-	ast_format_cap_remove_by_type(ast_channel_nativeformats(channel->owner), AST_MEDIA_TYPE_AUDIO);
+	//length = 1;												//set only one codec
+	//ast_debug(10, "%s: set native Formats length: %d\n", (char *) channel->currentDeviceId, length);
+	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!caps) {
+		return FALSE;
+	}
+	ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(channel->owner), AST_MEDIA_TYPE_UNKNOWN);
+	ast_format_cap_remove_by_type(caps, AST_MEDIA_TYPE_AUDIO);
 	//pbx_format_cap_append_skinny(ast_channel_nativeformats(channel->owner), codec);			// if length != 1
 	for (i = 0; i < length; i++) {
 		struct ast_format *format = sccp_asterisk114_skinny2ast_format(codec[1]);
 		if (format != ast_format_none) {
 			unsigned int framing = ast_format_get_default_ms(format);
-			ast_format_cap_append(ast_channel_nativeformats(channel->owner), format, framing);
+			ast_format_cap_append(caps, format, framing);
 		}
 	}
+	ast_channel_lock(channel->owner);
+	ast_channel_nativeformats_set(channel->owner, caps);
+	ast_channel_unlock(channel->owner);
+	ao2_cleanup(caps);
 
 	return 1;
 }
@@ -928,13 +933,23 @@ static int sccp_wrapper_asterisk114_setNativeVideoFormats(constChannelPtr channe
 	int i;
 	int length = 1;
 
+	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!caps) {
+		return FALSE;
+	}
+	ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(channel->owner), AST_MEDIA_TYPE_UNKNOWN);
+	ast_format_cap_remove_by_type(caps, AST_MEDIA_TYPE_VIDEO);
 	for (i = 0; i < length; i++) {
 		struct ast_format *format = sccp_asterisk114_skinny2ast_format(codec);
 		if (format != ast_format_none) {
 			unsigned int framing = ast_format_get_default_ms(format);
-			ast_format_cap_append(ast_channel_nativeformats(channel->owner), format, framing);
+			ast_format_cap_append(caps, format, framing);
 		}
 	}
+	ast_channel_lock(channel->owner);
+	ast_channel_nativeformats_set(channel->owner, caps);
+	ast_channel_unlock(channel->owner);
+	ao2_cleanup(caps);
 	return 1;
 }
 
@@ -1016,6 +1031,11 @@ static boolean_t sccp_wrapper_asterisk114_allocPBXChannel(sccp_channel_t * chann
 		return FALSE;
 	}
 
+	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!caps) {
+		return FALSE;
+	}
+
 	if (ids) {
 		assignedids = ids;
 	}
@@ -1024,6 +1044,7 @@ static boolean_t sccp_wrapper_asterisk114_allocPBXChannel(sccp_channel_t * chann
 	pbxDstChannel = ast_channel_alloc(0, AST_STATE_DOWN, line->cid_num, line->cid_name, line->accountcode, line->name, line->context, assignedids, pbxSrcChannel, line->amaflags, "%s", channel->designator);
 	if (pbxDstChannel == NULL) {
 		pbx_log(LOG_ERROR, "SCCP: (allocPBXChannel) ast_channel_alloc failed\n");
+		ao2_cleanup(caps);
 		return FALSE;
 	}
 	ast_channel_stage_snapshot(pbxDstChannel);
@@ -1031,14 +1052,8 @@ static boolean_t sccp_wrapper_asterisk114_allocPBXChannel(sccp_channel_t * chann
 
 	ast_channel_tech_set(pbxDstChannel, &sccp_tech);
 	ast_channel_tech_pvt_set(pbxDstChannel, sccp_channel_retain(channel));
-	//ast_channel_tech_pvt_set(pbxDstChannel, channel);
 
 	/* Copy Codec from SrcChannel */
-	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
-	if (!caps) {
-		return NULL;
-	}
-
 	if (pbxSrcChannel && ast_format_cap_count(ast_channel_nativeformats(pbxSrcChannel)) > 0) {
 		ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(pbxSrcChannel), AST_MEDIA_TYPE_UNKNOWN);
 	} else if (line && channel) {
@@ -1048,11 +1063,8 @@ static boolean_t sccp_wrapper_asterisk114_allocPBXChannel(sccp_channel_t * chann
 #endif		
 	}
 	ast_channel_nativeformats_set(pbxDstChannel, caps);
-	ao2_ref(caps, -1);
-	
-	struct ast_format *tmpfmt = ast_format_cap_get_format(ast_channel_nativeformats(pbxDstChannel), 0);
-	//struct ast_str *codec_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
-	//pbx_log(LOG_NOTICE, "allocPBXChannel: tmp->nativeformats=%s fmt=%s\n", ast_format_cap_get_names(ast_channel_nativeformats(pbxDstChannel), &codec_buf), ast_format_get_name(tmpfmt));
+	struct ast_format *tmpfmt = ast_format_cap_get_format(caps, 0);
+	ao2_cleanup(caps);
 	ast_channel_set_writeformat(pbxDstChannel, tmpfmt);
 	ast_channel_set_rawwriteformat(pbxDstChannel, tmpfmt);
 	ast_channel_set_readformat(pbxDstChannel, tmpfmt);
@@ -1150,7 +1162,7 @@ static boolean_t sccp_wrapper_asterisk114_allocTempPBXChannel(PBX_CHANNEL_TYPE *
 	PBX_CHANNEL_TYPE *pbxDstChannel = NULL;
 	struct ast_assigned_ids assignedids = {NULL, NULL};
 
-	struct ast_format *ast_format;
+	struct ast_format *tmpfmt;
 	unsigned int framing;
 
 	if (!pbxSrcChannel) {
@@ -1167,31 +1179,41 @@ static boolean_t sccp_wrapper_asterisk114_allocTempPBXChannel(PBX_CHANNEL_TYPE *
 		assignedids.uniqueid2 = uniqueid2;
 	}
 */
+	struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!caps) {
+		return FALSE;
+	}
 
 	ast_channel_lock(pbxSrcChannel);
 	pbxDstChannel = ast_channel_alloc(0, AST_STATE_DOWN, 0, 0, ast_channel_accountcode(pbxSrcChannel), pbx_channel_exten(pbxSrcChannel), pbx_channel_context(pbxSrcChannel), &assignedids, pbxSrcChannel, ast_channel_amaflags(pbxSrcChannel), "%s-TMP", ast_channel_name(pbxSrcChannel));
 	if (pbxDstChannel == NULL) {
 		pbx_log(LOG_ERROR, "SCCP: (alloc_conferenceTempPBXChannel) ast_channel_alloc failed\n");
+		ast_channel_unlock(pbxSrcChannel);
+		ao2_cleanup(caps);
 		return FALSE;
 	}
 
 	ast_channel_stage_snapshot(pbxDstChannel);
-	// ast_channel_tech_set(pbxDstChannel, &sccp_tech);
 	ast_channel_tech_set(pbxDstChannel, &null_tech);							// USE null_tech to prevent fixup issues. Channel is only used to masquerade a channel out of a running bridge.
 
-	// if (ast_format_cap_is_empty(pbx_channel_nativeformats(pbxSrcChannel))) {
+	/* Copy Codec from SrcChannel */
 	if (ast_format_cap_count(pbx_channel_nativeformats(pbxSrcChannel)) == 0) {
-		ast_format = ast_format_alaw;
-		ao2_ref(ast_format, +1);
+		tmpfmt = ast_format_alaw;
+		//tmpfmt = ast_format_slin;
+		ao2_ref(tmpfmt, +1);
 	} else {
-		ast_format = ast_format_cap_get_best_by_type(pbx_channel_nativeformats(pbxSrcChannel), AST_MEDIA_TYPE_AUDIO);
+		tmpfmt = ast_format_cap_get_best_by_type(pbx_channel_nativeformats(pbxSrcChannel), AST_MEDIA_TYPE_AUDIO);
 	}
-	framing = ast_format_get_default_ms(ast_format);
-	ast_format_cap_remove_by_type(ast_channel_nativeformats(pbxDstChannel), AST_MEDIA_TYPE_AUDIO);
-	ast_format_cap_append(ast_channel_nativeformats(pbxDstChannel), ast_format, framing);
-	ast_set_read_format(pbxDstChannel, ast_format);
-	ast_set_write_format(pbxDstChannel, ast_format);
-	ao2_ref(ast_format, -1);
+	framing = ast_format_get_default_ms(tmpfmt);
+	ast_format_cap_append(caps, tmpfmt, framing);
+	ast_channel_nativeformats_set(pbxDstChannel, caps);
+	ao2_cleanup(caps);
+	ast_channel_set_writeformat(pbxDstChannel, tmpfmt);
+	ast_channel_set_rawwriteformat(pbxDstChannel, tmpfmt);
+	ast_channel_set_readformat(pbxDstChannel, tmpfmt);
+	ast_channel_set_rawreadformat(pbxDstChannel, tmpfmt);
+	ao2_ref(tmpfmt, -1);
+	/* EndCodec */
 
 	ast_channel_context_set(pbxDstChannel, ast_channel_context(pbxSrcChannel));
 	ast_channel_exten_set(pbxDstChannel, ast_channel_exten(pbxSrcChannel));
@@ -1202,7 +1224,8 @@ static boolean_t sccp_wrapper_asterisk114_allocTempPBXChannel(PBX_CHANNEL_TYPE *
 	ast_channel_unlock(pbxSrcChannel);
 	ast_channel_unlock(pbxDstChannel);
 
-	(*_pbxDstChannel) = pbx_channel_ref(pbxDstChannel);
+	(*_pbxDstChannel) = pbxDstChannel;
+
 	return TRUE;
 }
 
@@ -1581,12 +1604,14 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk114_request(const char *type, stru
 	/** workaround for asterisk console log flooded
 	 channel.c:5080 ast_write: Codec mismatch on channel SCCP/xxx-0000002d setting write format to g722 from unknown native formats (nothing)
 	*/
+/*
 	if (!channel->capabilities.audio[0]) {
 		skinny_codec_t codecs[] = { SKINNY_CODEC_WIDEBAND_256K };
 		sccp_wrapper_asterisk114_setNativeAudioFormats(channel, codecs, 1);
 		sccp_wrapper_asterisk114_setReadFormat(channel, SKINNY_CODEC_WIDEBAND_256K);
 		sccp_wrapper_asterisk114_setWriteFormat(channel, SKINNY_CODEC_WIDEBAND_256K);
 	}
+*/
 	
 	/* get remote codecs from channel driver */
 	//ast_rtp_instance_get_codecs(c->rtp.adio.rtp);
@@ -1699,6 +1724,8 @@ static int sccp_wrapper_asterisk114_fixup(PBX_CHANNEL_TYPE * oldchan, PBX_CHANNE
 
 			//! \todo update remote capabilities after fixup
 
+			struct ast_str *codec_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
+			pbx_log(LOG_NOTICE, "Fixup: nativeformats=%s\n", ast_format_cap_get_names(ast_channel_nativeformats(newchan), &codec_buf));
 		}
 	} else {
 		pbx_log(LOG_WARNING, "sccp_pbx_fixup(old: %s(%p), new: %s(%p)). no SCCP channel to fix\n", pbx_channel_name(oldchan), (void *) oldchan, pbx_channel_name(newchan), (void *) newchan);
@@ -2284,23 +2311,9 @@ static boolean_t sccp_wrapper_asterisk114_setWriteFormat(constChannelPtr channel
 		return FALSE;
 	}
 
+	pbx_log(LOG_NOTICE, "%s: setWriteFormat:%s\n", channel->designator, codec2str(codec));
 	struct ast_format *ast_format = sccp_asterisk114_skinny2ast_format(codec);
-	if (ast_format != ast_format_none) {
-		struct ast_format_cap *cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
-		if (!cap) {
-			ao2_cleanup(cap);
-			return FALSE;
-		}
-
-		unsigned int framing = ast_format_get_default_ms(ast_format);
-		ast_format_cap_append(cap, ast_format, framing);
-		ast_set_write_format_from_cap(channel->owner, cap);
-
-		ao2_ref(cap, -1);
-		cap = NULL;
-	} else {
-		return FALSE;
-	}
+	ast_set_write_format(channel->owner, ast_format);
 
 	if (NULL != channel->rtp.audio.instance) {
 		ast_rtp_instance_set_write_format(channel->rtp.audio.instance, ast_format);
@@ -2310,28 +2323,12 @@ static boolean_t sccp_wrapper_asterisk114_setWriteFormat(constChannelPtr channel
 
 static boolean_t sccp_wrapper_asterisk114_setReadFormat(constChannelPtr channel, skinny_codec_t codec)
 {
-	//! \todo possibly needs to be synced to ast108
 	if (!channel) {
 		return FALSE;
 	}
-
+	pbx_log(LOG_NOTICE, "%s: setReadFormat:%s\n", channel->designator, codec2str(codec));
 	struct ast_format *ast_format = sccp_asterisk114_skinny2ast_format(codec);
-	if (ast_format != ast_format_none) {
-		struct ast_format_cap *cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
-		if (!cap) {
-			ao2_cleanup(cap);
-			return FALSE;
-		}
-
-		unsigned int framing = ast_format_get_default_ms(ast_format);
-		ast_format_cap_append(cap, ast_format, framing);
-		ast_set_read_format_from_cap(channel->owner, cap);
-
-		ao2_ref(cap, -1);
-		cap = NULL;
-	} else {
-		return FALSE;
-	}
+	ast_set_read_format(channel->owner, ast_format);
 
 	if (NULL != channel->rtp.audio.instance) {
 		ast_rtp_instance_set_read_format(channel->rtp.audio.instance, ast_format);

--- a/src/pbx_impl/ast114/ast114.c
+++ b/src/pbx_impl/ast114/ast114.c
@@ -94,6 +94,7 @@ static boolean_t sccp_wrapper_asterisk114_setReadFormat(constChannelPtr channel,
 PBX_CHANNEL_TYPE *sccp_wrapper_asterisk114_findPickupChannelByExtenLocked(PBX_CHANNEL_TYPE * chan, const char *exten, const char *context);
 PBX_CHANNEL_TYPE *sccp_wrapper_asterisk114_findPickupChannelByGroupLocked(PBX_CHANNEL_TYPE * chan);
 
+/*
 static inline skinny_codec_t sccp_asterisk114_getSkinnyFormatSingle(struct ast_format_cap *ast_format_capability)
 {
 	uint formatPosition;
@@ -114,7 +115,7 @@ static inline skinny_codec_t sccp_asterisk114_getSkinnyFormatSingle(struct ast_f
 	return codec;
 }
 
-static uint8_t sccp_asterisk114_getSkinnyFormatMultiple(struct ast_format_cap *ast_format_capability, skinny_codec_t codec[], int length)
+*/static uint8_t sccp_asterisk114_getSkinnyFormatMultiple(struct ast_format_cap *ast_format_capability, skinny_codec_t codec[], int length)
 {
 	// struct ast_format tmp_fmt;
 	uint formatPosition;
@@ -1153,7 +1154,7 @@ static boolean_t sccp_wrapper_asterisk114_masqueradeHelper(PBX_CHANNEL_TYPE * pb
 		ast_hangup(pbxTmpChannel);
 	}
 	pbx_log(LOG_NOTICE, "SCCP: (masqueradeHelper) remove reference from pbxTmpChannel: %s\n", ast_channel_name(pbxTmpChannel));
-	pbxTmpChannel = ast_channel_unref(pbxTmpChannel);
+	pbx_channel_unref(pbxTmpChannel);
 	return res;
 }
 
@@ -1450,15 +1451,17 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk114_request(const char *type, stru
 	struct ast_str *codec_buf = ast_str_alloca(64);
 	ast_callid callid = 0;
 
-	skinny_codec_t audioCapabilities[SKINNY_MAX_CAPABILITIES];
-	skinny_codec_t videoCapabilities[SKINNY_MAX_CAPABILITIES];
+	skinny_codec_t audioCapabilities[SKINNY_MAX_CAPABILITIES] = {0};
+	skinny_codec_t videoCapabilities[SKINNY_MAX_CAPABILITIES] = {0};
 
 	memset(&audioCapabilities, 0, sizeof(audioCapabilities));
 	memset(&videoCapabilities, 0, sizeof(videoCapabilities));
 
 	//! \todo parse request
 	char *lineName;
-	skinny_codec_t codec = SKINNY_CODEC_G711_ULAW_64K;
+	skinny_codec_t audio_codec = SKINNY_CODEC_G722_64K;
+	skinny_codec_t video_codec = SKINNY_CODEC_H264;
+
 	sccp_autoanswer_t autoanswer_type = SCCP_AUTOANSWER_NONE;
 	uint8_t autoanswer_cause = AST_CAUSE_NOTDEFINED;
 	skinny_ringtype_t ringermode = GLOB(ringtype);
@@ -1502,16 +1505,25 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk114_request(const char *type, stru
 		*cause = autoanswer_cause;
 	}
 
-	/** getting remote capabilities */
-	char cap_buf[512];
+	/** get requested format */
+	if ( (audio_codec = pbx_codec2skinny_codec(ast_format_compatibility_format2bitfield(ast_format_cap_get_best_by_type(cap, AST_MEDIA_TYPE_AUDIO)))) == SKINNY_CODEC_NONE) {
+		pbx_log(LOG_NOTICE, "Could not match audio codec, Falling back to ULAW\n");
+		audio_codec = SKINNY_CODEC_G722_64K;
+	}
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "SCCP: requested Audio Codec in Skinny Format: %s\n", codec2str(audio_codec));
+#ifdef CS_SCCP_VIDEO
+	if ( (video_codec = pbx_codec2skinny_codec(ast_format_compatibility_format2bitfield(ast_format_cap_get_best_by_type(cap, AST_MEDIA_TYPE_VIDEO)))) == SKINNY_CODEC_NONE) {
+		pbx_log(LOG_NOTICE, "Could not match video codec. No Video\n");
+		video_codec = 0;
+	}
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "SCCP: requested Video Codec in Skinny Format: %s\n", codec2str(video_codec));
+#endif
 
-	/* audio capabilities */
+	/** getting remote capabilities */
 	if (requestor) {
 		AUTO_RELEASE(sccp_channel_t, remoteSccpChannel , get_sccp_channel_from_pbx_channel(requestor));
 		if (remoteSccpChannel) {
-			uint8_t x, y, z;
-
-			z = 0;
+			uint8_t x, y, z = 0;
 			/* shrink audioCapabilities to remote preferred/capable format */
 			for (x = 0; x < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->preferences.audio[x] != 0; x++) {
 				for (y = 0; y < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->capabilities.audio[y] != 0; y++) {
@@ -1522,32 +1534,48 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk114_request(const char *type, stru
 				}
 			}
 		} else {
-			if (!sccp_asterisk114_getSkinnyFormatMultiple(ast_channel_nativeformats(requestor), audioCapabilities, ARRAY_LEN(audioCapabilities))) {
+			struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+			ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(requestor), AST_MEDIA_TYPE_AUDIO);
+			if (!sccp_asterisk114_getSkinnyFormatMultiple(caps, audioCapabilities, ARRAY_LEN(audioCapabilities))) {
 				pbx_log(LOG_NOTICE, "SCCP: remote native format is not compatible with any skinny format. Transcoding required\n");
 				audioCapabilities[0] = SKINNY_CODEC_WIDEBAND_256K;
 			}
+			ao2_cleanup(caps);
 		}
-
-		/* video capabilities */
-		sccp_asterisk114_getSkinnyFormatMultiple(ast_channel_nativeformats(requestor), videoCapabilities, ARRAY_LEN(videoCapabilities));	//replace AUDIO_MASK with AST_FORMAT_TYPE_AUDIO check
+#ifdef CS_SCCP_VIDEO
+		if (remoteSccpChannel) {
+			uint8_t x, y, z = 0;
+			for (x = 0; x < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->preferences.video[x] != 0; x++) {
+				for (y = 0; y < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->capabilities.video[y] != 0; y++) {
+					if (remoteSccpChannel->preferences.video[x] == remoteSccpChannel->capabilities.video[y]) {
+						videoCapabilities[z++] = remoteSccpChannel->preferences.video[x];
+						break;
+					}
+				}
+			}
+		} else {
+			struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+			ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(requestor), AST_MEDIA_TYPE_VIDEO);
+			sccp_asterisk114_getSkinnyFormatMultiple(caps, videoCapabilities, ARRAY_LEN(videoCapabilities));
+			ao2_cleanup(caps);
+		}
+#endif
+	} else {
+		audioCapabilities[0] = audio_codec;
+		videoCapabilities[0] = video_codec;
 	}
-
+	char cap_buf[512];
 	sccp_codec_multiple2str(cap_buf, sizeof(cap_buf) - 1, audioCapabilities, ARRAY_LEN(audioCapabilities));
-	// sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote audio caps: %s\n", cap_buf);
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote audio caps: %s\n", cap_buf);
 
 	sccp_codec_multiple2str(cap_buf, sizeof(cap_buf) - 1, videoCapabilities, ARRAY_LEN(videoCapabilities));
-	// sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote video caps: %s\n", cap_buf);
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote video caps: %s\n", cap_buf);
 	/** done */
-
-	/** get requested format */
-	//codec = pbx_codec2skinny_codec(ast_format_compatibility_format2bitfield(format));
-	codec = sccp_asterisk114_getSkinnyFormatSingle(cap);
-	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "SCCP: requestedCodec in Skinny Format: %d\n", codec);
 
 	int callid_created = ast_callid_threadstorage_auto(&callid);
 
 	AUTO_RELEASE(sccp_channel_t, channel , NULL);
-	requestStatus = sccp_requestChannel(lineName, codec, audioCapabilities, ARRAY_LEN(audioCapabilities), autoanswer_type, autoanswer_cause, ringermode, &channel);
+	requestStatus = sccp_requestChannel(lineName, audio_codec, audioCapabilities, ARRAY_LEN(audioCapabilities), autoanswer_type, autoanswer_cause, ringermode, &channel);
 	switch (requestStatus) {
 		case SCCP_REQUEST_STATUS_SUCCESS:								// everything is fine
 			break;
@@ -1568,6 +1596,14 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk114_request(const char *type, stru
 			*cause = AST_CAUSE_UNALLOCATED;
 			goto EXITFUNC;
 	}
+#ifdef CS_SCCP_VIDEO
+	memset(&channel->remoteCapabilities.video, 0, sizeof(channel->remoteCapabilities.video));
+	if (videoCapabilities[0] != SKINNY_CODEC_NONE) {
+		memcpy(channel->remoteCapabilities.video, videoCapabilities, ARRAY_LEN(videoCapabilities));
+	} else if (video_codec) {
+		channel->remoteCapabilities.video[0] = video_codec;
+	}
+#endif
 	
 	if (!sccp_pbx_channel_allocate(channel, assignedids, requestor)) {
 		//! \todo handle error in more detail, cleanup sccp channel
@@ -1600,23 +1636,6 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk114_request(const char *type, stru
 				SCCP_CALLINFO_ORIG_CALLEDPARTY_NUMBER, ast_channel_redirecting((PBX_CHANNEL_TYPE *) requestor)->orig.number.str,
 				SCCP_CALLINFO_KEY_SENTINEL);
 	}
-
-	/** workaround for asterisk console log flooded
-	 channel.c:5080 ast_write: Codec mismatch on channel SCCP/xxx-0000002d setting write format to g722 from unknown native formats (nothing)
-	*/
-/*
-	if (!channel->capabilities.audio[0]) {
-		skinny_codec_t codecs[] = { SKINNY_CODEC_WIDEBAND_256K };
-		sccp_wrapper_asterisk114_setNativeAudioFormats(channel, codecs, 1);
-		sccp_wrapper_asterisk114_setReadFormat(channel, SKINNY_CODEC_WIDEBAND_256K);
-		sccp_wrapper_asterisk114_setWriteFormat(channel, SKINNY_CODEC_WIDEBAND_256K);
-	}
-*/
-	
-	/* get remote codecs from channel driver */
-	//ast_rtp_instance_get_codecs(c->rtp.adio.rtp);
-	//ast_rtp_instance_get_codecs(c->rtp.video.instance);
-	/** done */
 
 EXITFUNC:
 	if (channel) {
@@ -1716,12 +1735,9 @@ static int sccp_wrapper_asterisk114_fixup(PBX_CHANNEL_TYPE * oldchan, PBX_CHANNE
 				// set channel requestHangup to use ast_hangup (as it will not be part of __ast_pbx_run anymore, upon returning from masquerade)
 				c->hangupRequest = sccp_wrapper_asterisk_requestHangup;
 			}
-			// c->owner = ast_channel_ref(newchan);
-			// ast_channel_unref(oldchan);
 			sccp_wrapper_asterisk114_setOwner(c, newchan);
 			//! \todo force update of rtp peer for directrtp
 			// sccp_wrapper_asterisk114_update_rtp_peer(newchan, NULL, NULL, 0, 0, 0);
-
 			//! \todo update remote capabilities after fixup
 
 			struct ast_str *codec_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
@@ -2311,7 +2327,7 @@ static boolean_t sccp_wrapper_asterisk114_setWriteFormat(constChannelPtr channel
 		return FALSE;
 	}
 
-	pbx_log(LOG_NOTICE, "%s: setWriteFormat:%s\n", channel->designator, codec2str(codec));
+	//sccp_log(DEBUGCAT_CODEC)(VERBOSE_PREFIX_1 "%s: setWriteFormat:%s\n", channel->designator, codec2str(codec));
 	struct ast_format *ast_format = sccp_asterisk114_skinny2ast_format(codec);
 	ast_set_write_format(channel->owner, ast_format);
 
@@ -2326,7 +2342,7 @@ static boolean_t sccp_wrapper_asterisk114_setReadFormat(constChannelPtr channel,
 	if (!channel) {
 		return FALSE;
 	}
-	pbx_log(LOG_NOTICE, "%s: setReadFormat:%s\n", channel->designator, codec2str(codec));
+	//sccp_log(DEBUGCAT_CODEC)(VERBOSE_PREFIX_1 "%s: setReadFormat:%s\n", channel->designator, codec2str(codec));
 	struct ast_format *ast_format = sccp_asterisk114_skinny2ast_format(codec);
 	ast_set_read_format(channel->owner, ast_format);
 

--- a/src/pbx_impl/ast115/ast115.c
+++ b/src/pbx_impl/ast115/ast115.c
@@ -1451,7 +1451,11 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk115_request(const char *type, stru
 	sccp_channel_request_status_t requestStatus;
 	PBX_CHANNEL_TYPE *result_ast_channel = NULL;
 	struct ast_str *codec_buf = ast_str_alloca(64);
+#if !defined(CS_AST_CHANNEL_CALLID_TYPEDEF)
+	struct ast_callid *callid = NULL;
+#else	
 	ast_callid callid = 0;
+#endif
 
 	skinny_codec_t audioCapabilities[SKINNY_MAX_CAPABILITIES] = {0};
 	skinny_codec_t videoCapabilities[SKINNY_MAX_CAPABILITIES] = {0};

--- a/src/pbx_impl/ast115/ast115.c
+++ b/src/pbx_impl/ast115/ast115.c
@@ -94,6 +94,7 @@ static boolean_t sccp_wrapper_asterisk115_setReadFormat(constChannelPtr channel,
 PBX_CHANNEL_TYPE *sccp_wrapper_asterisk115_findPickupChannelByExtenLocked(PBX_CHANNEL_TYPE * chan, const char *exten, const char *context);
 PBX_CHANNEL_TYPE *sccp_wrapper_asterisk115_findPickupChannelByGroupLocked(PBX_CHANNEL_TYPE * chan);
 
+/*
 static inline skinny_codec_t sccp_asterisk115_getSkinnyFormatSingle(struct ast_format_cap *ast_format_capability)
 {
 	uint formatPosition;
@@ -113,7 +114,7 @@ static inline skinny_codec_t sccp_asterisk115_getSkinnyFormatSingle(struct ast_f
 
 	return codec;
 }
-
+*/
 static uint8_t sccp_asterisk115_getSkinnyFormatMultiple(struct ast_format_cap *ast_format_capability, skinny_codec_t codec[], int length)
 {
 	// struct ast_format tmp_fmt;
@@ -123,7 +124,7 @@ static uint8_t sccp_asterisk115_getSkinnyFormatMultiple(struct ast_format_cap *a
 	struct ast_str *codec_buf = ast_str_alloca(64);
 	struct ast_format *format;
 
-	sccp_log(DEBUGCAT_RTP)(VERBOSE_PREFIX_3 "SCCP: (getSkinnyFormatSingle) caps %s\n", ast_format_cap_get_names(ast_format_capability,&codec_buf));
+	sccp_log(DEBUGCAT_CODEC)(VERBOSE_PREFIX_3 "SCCP: (getSkinnyFormatMultiple) caps %s\n", ast_format_cap_get_names(ast_format_capability,&codec_buf));
 
 	for (formatPosition = 0; formatPosition < ast_format_cap_count(ast_format_capability); ++formatPosition) {
 		format = ast_format_cap_get_format(ast_format_capability, formatPosition);
@@ -1154,7 +1155,7 @@ static boolean_t sccp_wrapper_asterisk115_masqueradeHelper(PBX_CHANNEL_TYPE * pb
 		ast_hangup(pbxTmpChannel);
 	}
 	pbx_log(LOG_NOTICE, "SCCP: (masqueradeHelper) remove reference from pbxTmpChannel: %s\n", ast_channel_name(pbxTmpChannel));
-	pbxTmpChannel = ast_channel_unref(pbxTmpChannel);
+	pbx_channel_unref(pbxTmpChannel);
 	return res;
 }
 
@@ -1376,7 +1377,8 @@ static uint8_t sccp_wrapper_asterisk115_get_payloadType(const struct sccp_rtp *r
 {
 	struct ast_format *astCodec = sccp_asterisk115_skinny2ast_format(codec);
 	if (astCodec != ast_format_none) {
-		return ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(rtp->instance), skinny_codec2pbx_codec(codec), astCodec, 0);
+		//return ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(rtp->instance), skinny_codec2pbx_codec(codec), astCodec, 0);
+		return ast_rtp_codecs_payload_code(ast_rtp_instance_get_codecs(rtp->instance), 0, astCodec, 0);
 	}
 	return 0;
 }
@@ -1451,15 +1453,17 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk115_request(const char *type, stru
 	struct ast_str *codec_buf = ast_str_alloca(64);
 	ast_callid callid = 0;
 
-	skinny_codec_t audioCapabilities[SKINNY_MAX_CAPABILITIES];
-	skinny_codec_t videoCapabilities[SKINNY_MAX_CAPABILITIES];
+	skinny_codec_t audioCapabilities[SKINNY_MAX_CAPABILITIES] = {0};
+	skinny_codec_t videoCapabilities[SKINNY_MAX_CAPABILITIES] = {0};
 
 	memset(&audioCapabilities, 0, sizeof(audioCapabilities));
 	memset(&videoCapabilities, 0, sizeof(videoCapabilities));
 
 	//! \todo parse request
 	char *lineName;
-	skinny_codec_t codec = SKINNY_CODEC_G711_ULAW_64K;
+	skinny_codec_t audio_codec = SKINNY_CODEC_G722_64K;
+	skinny_codec_t video_codec = SKINNY_CODEC_H264;
+
 	sccp_autoanswer_t autoanswer_type = SCCP_AUTOANSWER_NONE;
 	uint8_t autoanswer_cause = AST_CAUSE_NOTDEFINED;
 	skinny_ringtype_t ringermode = GLOB(ringtype);
@@ -1503,16 +1507,25 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk115_request(const char *type, stru
 		*cause = autoanswer_cause;
 	}
 
-	/** getting remote capabilities */
-	char cap_buf[512];
+	/** get requested format */
+	if ( (audio_codec = pbx_codec2skinny_codec(ast_format_compatibility_format2bitfield(ast_format_cap_get_best_by_type(cap, AST_MEDIA_TYPE_AUDIO)))) == SKINNY_CODEC_NONE) {
+		pbx_log(LOG_NOTICE, "Could not match audio codec, Falling back to ULAW\n");
+		audio_codec = SKINNY_CODEC_G722_64K;
+	}
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "SCCP: requested Audio Codec in Skinny Format: %s\n", codec2str(audio_codec));
+#ifdef CS_SCCP_VIDEO
+	if ( (video_codec = pbx_codec2skinny_codec(ast_format_compatibility_format2bitfield(ast_format_cap_get_best_by_type(cap, AST_MEDIA_TYPE_VIDEO)))) == SKINNY_CODEC_NONE) {
+		pbx_log(LOG_NOTICE, "Could not match video codec. No Video\n");
+		video_codec = 0;
+	}
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "SCCP: requested Video Codec in Skinny Format: %s\n", codec2str(video_codec));
+#endif
 
-	/* audio capabilities */
+	/** getting remote capabilities */
 	if (requestor) {
 		AUTO_RELEASE(sccp_channel_t, remoteSccpChannel , get_sccp_channel_from_pbx_channel(requestor));
 		if (remoteSccpChannel) {
-			uint8_t x, y, z;
-
-			z = 0;
+			uint8_t x, y, z = 0;
 			/* shrink audioCapabilities to remote preferred/capable format */
 			for (x = 0; x < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->preferences.audio[x] != 0; x++) {
 				for (y = 0; y < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->capabilities.audio[y] != 0; y++) {
@@ -1523,32 +1536,48 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk115_request(const char *type, stru
 				}
 			}
 		} else {
-			if (!sccp_asterisk115_getSkinnyFormatMultiple(ast_channel_nativeformats(requestor), audioCapabilities, ARRAY_LEN(audioCapabilities))) {
+			struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+			ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(requestor), AST_MEDIA_TYPE_AUDIO);
+			if (!sccp_asterisk115_getSkinnyFormatMultiple(caps, audioCapabilities, ARRAY_LEN(audioCapabilities))) {
 				pbx_log(LOG_NOTICE, "SCCP: remote native format is not compatible with any skinny format. Transcoding required\n");
 				audioCapabilities[0] = SKINNY_CODEC_WIDEBAND_256K;
 			}
+			ao2_cleanup(caps);
 		}
-
-		/* video capabilities */
-		sccp_asterisk115_getSkinnyFormatMultiple(ast_channel_nativeformats(requestor), videoCapabilities, ARRAY_LEN(videoCapabilities));	//replace AUDIO_MASK with AST_FORMAT_TYPE_AUDIO check
+#ifdef CS_SCCP_VIDEO
+		if (remoteSccpChannel) {
+			uint8_t x, y, z = 0;
+			for (x = 0; x < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->preferences.video[x] != 0; x++) {
+				for (y = 0; y < SKINNY_MAX_CAPABILITIES && remoteSccpChannel->capabilities.video[y] != 0; y++) {
+					if (remoteSccpChannel->preferences.video[x] == remoteSccpChannel->capabilities.video[y]) {
+						videoCapabilities[z++] = remoteSccpChannel->preferences.video[x];
+						break;
+					}
+				}
+			}
+		} else {
+			struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+			ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(requestor), AST_MEDIA_TYPE_VIDEO);
+			sccp_asterisk115_getSkinnyFormatMultiple(caps, videoCapabilities, ARRAY_LEN(videoCapabilities));
+			ao2_cleanup(caps);
+		}
+#endif
+	} else {
+		audioCapabilities[0] = audio_codec;
+		videoCapabilities[0] = video_codec;
 	}
-
+	char cap_buf[512];
 	sccp_codec_multiple2str(cap_buf, sizeof(cap_buf) - 1, audioCapabilities, ARRAY_LEN(audioCapabilities));
-	// sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote audio caps: %s\n", cap_buf);
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote audio caps: %s\n", cap_buf);
 
 	sccp_codec_multiple2str(cap_buf, sizeof(cap_buf) - 1, videoCapabilities, ARRAY_LEN(videoCapabilities));
-	// sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote video caps: %s\n", cap_buf);
+	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "remote video caps: %s\n", cap_buf);
 	/** done */
-
-	/** get requested format */
-	//codec = pbx_codec2skinny_codec(ast_format_compatibility_format2bitfield(format));
-	codec = sccp_asterisk115_getSkinnyFormatSingle(cap);
-	sccp_log(DEBUGCAT_CODEC) (VERBOSE_PREFIX_4 "SCCP: requestedCodec in Skinny Format: %d\n", codec);
 
 	int callid_created = ast_callid_threadstorage_auto(&callid);
 
 	AUTO_RELEASE(sccp_channel_t, channel , NULL);
-	requestStatus = sccp_requestChannel(lineName, codec, audioCapabilities, ARRAY_LEN(audioCapabilities), autoanswer_type, autoanswer_cause, ringermode, &channel);
+	requestStatus = sccp_requestChannel(lineName, audio_codec, audioCapabilities, ARRAY_LEN(audioCapabilities), autoanswer_type, autoanswer_cause, ringermode, &channel);
 	switch (requestStatus) {
 		case SCCP_REQUEST_STATUS_SUCCESS:								// everything is fine
 			break;
@@ -1569,6 +1598,14 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk115_request(const char *type, stru
 			*cause = AST_CAUSE_UNALLOCATED;
 			goto EXITFUNC;
 	}
+#ifdef CS_SCCP_VIDEO
+	memset(&channel->remoteCapabilities.video, 0, sizeof(channel->remoteCapabilities.video));
+	if (videoCapabilities[0] != SKINNY_CODEC_NONE) {
+		memcpy(channel->remoteCapabilities.video, videoCapabilities, ARRAY_LEN(videoCapabilities));
+	} else if (video_codec) {
+		channel->remoteCapabilities.video[0] = video_codec;
+	}
+#endif
 	
 	if (!sccp_pbx_channel_allocate(channel, assignedids, requestor)) {
 		//! \todo handle error in more detail, cleanup sccp channel
@@ -1601,24 +1638,6 @@ static PBX_CHANNEL_TYPE *sccp_wrapper_asterisk115_request(const char *type, stru
 				SCCP_CALLINFO_ORIG_CALLEDPARTY_NUMBER, ast_channel_redirecting((PBX_CHANNEL_TYPE *) requestor)->orig.number.str,
 				SCCP_CALLINFO_KEY_SENTINEL);
 	}
-
-	/** workaround for asterisk console log flooded
-	 channel.c:5080 ast_write: Codec mismatch on channel SCCP/xxx-0000002d setting write format to g722 from unknown native formats (nothing)
-	*/
-/*
-	if (!channel->capabilities.audio[0]) {
-		skinny_codec_t codecs[] = { SKINNY_CODEC_WIDEBAND_256K };
-		sccp_wrapper_asterisk115_setNativeAudioFormats(channel, codecs, 1);
-		sccp_wrapper_asterisk115_setReadFormat(channel, SKINNY_CODEC_WIDEBAND_256K);
-		sccp_wrapper_asterisk115_setWriteFormat(channel, SKINNY_CODEC_WIDEBAND_256K);
-	}
-*/
-	
-	/* get remote codecs from channel driver */
-	//ast_rtp_instance_get_codecs(c->rtp.adio.rtp);
-	//ast_rtp_instance_get_codecs(c->rtp.video.instance);
-	/** done */
-
 EXITFUNC:
 	if (channel) {
 		result_ast_channel = channel->owner;
@@ -1717,8 +1736,6 @@ static int sccp_wrapper_asterisk115_fixup(PBX_CHANNEL_TYPE * oldchan, PBX_CHANNE
 				// set channel requestHangup to use ast_hangup (as it will not be part of __ast_pbx_run anymore, upon returning from masquerade)
 				c->hangupRequest = sccp_wrapper_asterisk_requestHangup;
 			}
-			// c->owner = ast_channel_ref(newchan);
-			// ast_channel_unref(oldchan);
 			sccp_wrapper_asterisk115_setOwner(c, newchan);
 			//! \todo force update of rtp peer for directrtp
 			// sccp_wrapper_asterisk115_update_rtp_peer(newchan, NULL, NULL, 0, 0, 0);
@@ -2238,6 +2255,7 @@ static boolean_t sccp_wrapper_asterisk115_createRtpInstance(constDevicePtr d, co
 		// this prevent a warning about unknown codec, when rtp traffic starts */
 		ast_queue_frame(c->owner, &ast_null_frame);
 	}
+	ast_rtp_codecs_set_framing(ast_rtp_instance_get_codecs(instance), ast_format_cap_get_framing(ast_channel_nativeformats(c->owner)));
 
 	return TRUE;
 }
@@ -2312,7 +2330,7 @@ static boolean_t sccp_wrapper_asterisk115_setWriteFormat(constChannelPtr channel
 		return FALSE;
 	}
 
-	pbx_log(LOG_NOTICE, "%s: setWriteFormat:%s\n", channel->designator, codec2str(codec));
+	//sccp_log(DEBUGCAT_CODEC)(VERBOSE_PREFIX_1 "%s: setWriteFormat:%s\n", channel->designator, codec2str(codec));
 	struct ast_format *ast_format = sccp_asterisk115_skinny2ast_format(codec);
 	ast_set_write_format(channel->owner, ast_format);
 
@@ -2327,7 +2345,7 @@ static boolean_t sccp_wrapper_asterisk115_setReadFormat(constChannelPtr channel,
 	if (!channel) {
 		return FALSE;
 	}
-	pbx_log(LOG_NOTICE, "%s: setReadFormat:%s\n", channel->designator, codec2str(codec));
+	//sccp_log(DEBUGCAT_CODEC)(VERBOSE_PREFIX_1 "%s: setReadFormat:%s\n", channel->designator, codec2str(codec));
 	struct ast_format *ast_format = sccp_asterisk115_skinny2ast_format(codec);
 	ast_set_read_format(channel->owner, ast_format);
 

--- a/src/sccp_actions.c
+++ b/src/sccp_actions.c
@@ -3498,7 +3498,7 @@ void handle_OpenMultiMediaReceiveAck(constSessionPtr s, devicePtr d, constMessag
 	sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: Got Open MultiMedia Channel ACK. Status:'%s' (%d), Remote RTP/UDP:'%s', Type:%s, PassThruPartyId:%u, CallID:%u\n", d->id, skinny_mediastatus2str(mediastatus), mediastatus, sccp_netsock_stringify(&sas), (d->directrtp ? "DirectRTP" : "Indirect RTP"), passThruPartyId, callReference);
 
 	AUTO_RELEASE(sccp_channel_t, channel , __get_channel_from_callReference_or_passThruParty(d, callReference, 0, passThruPartyId));
-	if (do_expect(channel != NULL && channel->rtp.audio.receiveChannelState & SCCP_RTP_STATUS_PROGRESS)) {
+	if (do_expect(channel != NULL && channel->rtp.video.receiveChannelState & SCCP_RTP_STATUS_PROGRESS)) {
 		switch (mediastatus) {
 			case SKINNY_MEDIASTATUS_Ok:
 				sccp_rtp_set_phone(channel, &channel->rtp.video, &sas);
@@ -3523,7 +3523,7 @@ void handle_OpenMultiMediaReceiveAck(constSessionPtr s, devicePtr d, constMessag
 				sccp_channel_endcall(channel);
 				break;
 		}
-		channel->rtp.audio.receiveChannelState = resultingChannelState;
+		channel->rtp.video.receiveChannelState = resultingChannelState;
 	} else {
 		// we successfully opened receive channel, but have no channel active -> close receive (maybe the call was already (being) terminated)
 		if (mediastatus == SKINNY_MEDIASTATUS_Ok) {

--- a/src/sccp_channel.c
+++ b/src/sccp_channel.c
@@ -319,6 +319,7 @@ static void sccp_channel_recalculateReadformat(sccp_channel_t * channel)
 		return;
 	}
 	/* check if remote set a preferred format that is compatible */
+	char s1[512], s2[512], s3[512], s4[512];
 	if ((channel->rtp.audio.mediaTransmissionState == SCCP_RTP_STATUS_INACTIVE)
 	    || !sccp_codec_isCompatible(channel->rtp.audio.readFormat, channel->capabilities.audio, ARRAY_LEN(channel->capabilities.audio))
 	    ) {
@@ -327,17 +328,13 @@ static void sccp_channel_recalculateReadformat(sccp_channel_t * channel)
 
 		if (channel->rtp.audio.readFormat == SKINNY_CODEC_NONE) {
 			channel->rtp.audio.readFormat = SKINNY_CODEC_WIDEBAND_256K;
-
-			char s1[512];
-
 			sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "can not calculate readFormat, fall back to %s (%d)\n", sccp_codec_multiple2str(s1, sizeof(s1) - 1, &channel->rtp.audio.readFormat, 1), channel->rtp.audio.readFormat);
 		}
 		//iPbx.set_nativeAudioFormats(channel, channel->preferences.audio, ARRAY_LEN(channel->preferences.audio));
-		skinny_codec_t codecs[] = { channel->rtp.audio.readFormat };
-		iPbx.set_nativeAudioFormats(channel, codecs, 1);
+		//skinny_codec_t codecs[] = { channel->rtp.audio.readFormat };
+		//iPbx.set_nativeAudioFormats(channel, codecs, 1);
 		iPbx.rtp_setReadFormat(channel, channel->rtp.audio.readFormat);
 	}
-	char s1[512], s2[512], s3[512], s4[512];
 	sccp_log((DEBUGCAT_CODEC + DEBUGCAT_CHANNEL)) (VERBOSE_PREFIX_3 "%s: (recalculateReadformat) \n\tcapabilities: %s\n\tpreferences: %s\n\tremote caps: %s\n\tREAD:%s\n",
 		channel->designator, 
 		sccp_codec_multiple2str(s1, sizeof(s1) - 1, channel->capabilities.audio, ARRAY_LEN(channel->capabilities.audio)), 
@@ -360,6 +357,7 @@ static void sccp_channel_recalculateWriteformat(sccp_channel_t * channel)
 		return;
 	}
 	/* check if remote set a preferred format that is compatible */
+	char s1[512], s2[512], s3[512], s4[512];
 	if ((channel->rtp.audio.receiveChannelState == SCCP_RTP_STATUS_INACTIVE)
 	    || !sccp_codec_isCompatible(channel->rtp.audio.writeFormat, channel->capabilities.audio, ARRAY_LEN(channel->capabilities.audio))
 	    ) {
@@ -369,19 +367,15 @@ static void sccp_channel_recalculateWriteformat(sccp_channel_t * channel)
 
 		if (channel->rtp.audio.writeFormat == SKINNY_CODEC_NONE) {
 			channel->rtp.audio.writeFormat = SKINNY_CODEC_WIDEBAND_256K;
-
-			char s1[512];
-
 			sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "can not calculate writeFormat, fall back to %s (%d)\n", sccp_codec_multiple2str(s1, sizeof(s1) - 1, &channel->rtp.audio.writeFormat, 1), channel->rtp.audio.writeFormat);
 		}
 		//iPbx.set_nativeAudioFormats(channel, channel->preferences.audio, ARRAY_LEN(channel->preferences.audio));
-		skinny_codec_t codecs[] = { channel->rtp.audio.readFormat };
-		iPbx.set_nativeAudioFormats(channel, codecs, 1);
+		//skinny_codec_t codecs[] = { channel->rtp.audio.readFormat };
+		//iPbx.set_nativeAudioFormats(channel, codecs, 1);
 		iPbx.rtp_setWriteFormat(channel, channel->rtp.audio.writeFormat);
 	} else {
 		sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "%s: audio.receiveChannelState already active %d\n", channel->currentDeviceId, channel->rtp.audio.receiveChannelState);
 	}
-	char s1[512], s2[512], s3[512], s4[512];
 	sccp_log((DEBUGCAT_CODEC + DEBUGCAT_CHANNEL)) (VERBOSE_PREFIX_3 "%s: (recalculateWriteformat) \n\tcapabilities: %s\n\tpreferences: %s\n\tremote caps: %s\n\tWrite:%s\n",
 		channel->designator, 
 		sccp_codec_multiple2str(s1, sizeof(s1) - 1, channel->capabilities.audio, ARRAY_LEN(channel->capabilities.audio)), 
@@ -628,7 +622,7 @@ void sccp_channel_openReceiveChannel(constChannelPtr channel)
 
 	sccp_rtp_t *audio = (sccp_rtp_t *) &(channel->rtp.audio);
 	if (channel->owner) {
-		iPbx.set_nativeAudioFormats(channel, &audio->writeFormat, 1);
+		//iPbx.set_nativeAudioFormats(channel, channel->preferences.audio, ARRAY_LEN(channel->preferences.audio));
 		iPbx.rtp_setWriteFormat(channel, audio->writeFormat);
 	}
 
@@ -784,9 +778,8 @@ void sccp_channel_startMediaTransmission(constChannelPtr channel)
 		sccp_rtp_updateNatRemotePhone(channel, audio);
 	}
 
-	//sccp_channel_recalculateReadformat(channel);
 	if (channel->owner) {
-		iPbx.set_nativeAudioFormats(channel, &audio->readFormat, 1);
+		//iPbx.set_nativeAudioFormats(channel, channel->preferences.audio, ARRAY_LEN(channel->preferences.audio));
 		iPbx.rtp_setReadFormat(channel, audio->readFormat);
 	}
 
@@ -2528,10 +2521,10 @@ int sccp_channel_forward(sccp_channel_t * sccp_channel_parent, sccp_linedevices_
 		return -1;
 	}
 	/* Update rtp setting to match predecessor */
-	skinny_codec_t codecs[] = { SKINNY_CODEC_WIDEBAND_256K };
-	iPbx.set_nativeAudioFormats(sccp_forwarding_channel, codecs, 1);
-	iPbx.rtp_setWriteFormat(sccp_forwarding_channel, SKINNY_CODEC_WIDEBAND_256K);
-	iPbx.rtp_setReadFormat(sccp_forwarding_channel, SKINNY_CODEC_WIDEBAND_256K);
+	//skinny_codec_t codecs[] = { SKINNY_CODEC_WIDEBAND_256K };
+	//iPbx.set_nativeAudioFormats(sccp_forwarding_channel, codecs, 1);
+	//iPbx.rtp_setWriteFormat(sccp_forwarding_channel, SKINNY_CODEC_WIDEBAND_256K);
+	//iPbx.rtp_setReadFormat(sccp_forwarding_channel, SKINNY_CODEC_WIDEBAND_256K);
 	sccp_channel_updateChannelCapability(sccp_forwarding_channel);
 
 	/* setting callerid */

--- a/src/sccp_channel.c
+++ b/src/sccp_channel.c
@@ -637,12 +637,7 @@ void sccp_channel_openReceiveChannel(constChannelPtr channel)
 #ifdef CS_SCCP_VIDEO
 	if (sccp_device_isVideoSupported(d) && channel->videomode == SCCP_VIDEO_MODE_AUTO) {
 		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: We can have video, try to start vrtp\n", d->id);
-		if (!channel->rtp.video.instance && !sccp_rtp_createServer(d, (sccp_channel_t *)channel, SCCP_RTP_VIDEO)) {	// discard const
-			sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: can not start vrtp\n", d->id);
-		} else {
-			sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: video rtp started\n", d->id);
-			sccp_channel_startMultiMediaTransmission(channel);
-		}
+		sccp_channel_openMultiMediaReceiveChannel(channel);
 	}
 #endif
 }
@@ -891,40 +886,53 @@ void sccp_channel_updateMediaTransmission(constChannelPtr channel)
  */
 void sccp_channel_openMultiMediaReceiveChannel(constChannelPtr channel)
 {
-	uint32_t skinnyFormat;
-	int payloadType;
-	uint8_t lineInstance;
-	int bitRate = 1500;
-
 	pbx_assert(channel != NULL);
+	skinny_codec_t joint = SKINNY_CODEC_NONE;
+
 	AUTO_RELEASE(sccp_device_t, d , sccp_channel_getDevice(channel));
 
 	if (!d) {
 		return;
 	}
 
-	sccp_rtp_t *video = (sccp_rtp_t *) &(channel->rtp.video);
-	if ((video->receiveChannelState & SCCP_RTP_STATUS_ACTIVE)) {
+	char s1[512], s2[512];
+	sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_2 "%s: (openMultiMediaReceiveChannel) Checking codecs, local:%s, remote:%s\n", d->id,
+		sccp_codec_multiple2str(s1, sizeof(s1) - 1, channel->preferences.video, ARRAY_LEN(channel->preferences.video)),
+		sccp_codec_multiple2str(s2, sizeof(s2) - 1, channel->remoteCapabilities.video, ARRAY_LEN(channel->remoteCapabilities.video)));
+
+	// recalculate format;
+	if (channel->preferences.video[0] != SKINNY_CODEC_NONE && channel->remoteCapabilities.video[0] != SKINNY_CODEC_NONE) {
+		joint = sccp_codec_findBestJoint(channel->preferences.video, ARRAY_LEN(channel->preferences.video), channel->capabilities.video, ARRAY_LEN(channel->capabilities.video), channel->remoteCapabilities.video, ARRAY_LEN(channel->remoteCapabilities.video));
+		iPbx.set_nativeVideoFormats(channel, joint);
+		iPbx.rtp_setWriteFormat(channel, joint);
+	}
+
+	if (joint == SKINNY_CODEC_NONE) {
+		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_2 "%s: (openMultiMediaReceiveChannel) No joint codecs found\n", d->id);
 		return;
 	}
 
+	if (!channel->rtp.video.instance && !sccp_rtp_createServer(d, (sccp_channel_t *)channel, SCCP_RTP_VIDEO)) {	// discard const
+		pbx_log(LOG_WARNING, "%s: can not start vrtp\n", d->id);
+	}
+
+	sccp_rtp_t *video = (sccp_rtp_t *) &(channel->rtp.video);
+	if (video->receiveChannelState != SCCP_RTP_STATUS_INACTIVE) {
+		pbx_log(LOG_WARNING, "%s: Receive Channel already in progress\\n", d->id);
+		return;
+	}
 	//if (d->nat >= SCCP_NAT_ON) {
 	//	sccp_rtp_updateNatRemotePhone(channel, video);
 	//}
 
 	video->receiveChannelState |= SCCP_RTP_STATUS_PROGRESS;
-	skinnyFormat = video->writeFormat;
+	video->writeFormat = joint;
+	int payloadType = sccp_rtp_get_payloadType(&channel->rtp.video, video->writeFormat);
+	sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: using payload %d\n", d->id, payloadType);
+	uint8_t lineInstance = sccp_device_find_index_for_line(d, channel->line->name);
 
-	if (skinnyFormat == 0) {
-		pbx_log(LOG_NOTICE, "SCCP: Unable to find skinny format for %d\n", video->writeFormat);
-		return;
-	}
-
-	payloadType = sccp_rtp_get_payloadType(&channel->rtp.video, video->writeFormat);
-	lineInstance = sccp_device_find_index_for_line(d, channel->line->name);
-
-	sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: Open receive multimedia channel with format %s[%d] skinnyFormat %s[%d], payload %d\n", d->id, codec2str(video->writeFormat), video->writeFormat, codec2str(skinnyFormat), skinnyFormat, payloadType);
-	d->protocol->sendOpenMultiMediaChannel(d, channel, skinnyFormat, payloadType, lineInstance, bitRate);
+	sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: Open receive multimedia channel with format %s[%d] payload %d\n", d->id, codec2str(video->writeFormat), video->writeFormat, payloadType);
+	d->protocol->sendOpenMultiMediaChannel(d, channel, joint, payloadType, lineInstance, channel->maxBitRate);
 }
 
 int sccp_channel_receiveMultiMediaChannelOpen(sccp_device_t *d, sccp_channel_t *c)
@@ -950,6 +958,10 @@ int sccp_channel_receiveMultiMediaChannelOpen(sccp_device_t *d, sccp_channel_t *
 
 	sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: Opened MultiMedia Receive Channel (State: %s[%d])\n", d->id, sccp_channelstate2str(c->state), c->state);
 	c->rtp.video.receiveChannelState |= SCCP_RTP_STATUS_ACTIVE;
+
+	if (SCCP_RTP_STATUS_INACTIVE == c->rtp.video.mediaTransmissionState) {
+		sccp_channel_startMultiMediaTransmission(c);
+	}
 
 	if (c->owner && (c->state == SCCP_CHANNELSTATE_CONNECTED || c->state == SCCP_CHANNELSTATE_CONNECTEDCONFERENCE)) {
 		// force frame update
@@ -1029,69 +1041,66 @@ void sccp_channel_updateMultiMediaReceiveChannel(constChannelPtr channel)
  */
 void sccp_channel_startMultiMediaTransmission(constChannelPtr channel)
 {
-	int payloadType;
-	int bitRate = channel->maxBitRate;
-
 	pbx_assert(channel != NULL);
+	skinny_codec_t joint = SKINNY_CODEC_NONE;
 	AUTO_RELEASE(sccp_device_t, d , sccp_channel_getDevice(channel));
 
 	if (!d) {
 		return;
 	}
-	sccp_rtp_t *video = (sccp_rtp_t *) &(channel->rtp.video);
-	if (!video->instance) {
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: can't start vrtp media transmission, maybe channel is down %s\n", channel->currentDeviceId, channel->designator);
+
+	char s1[512], s2[512];
+	sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_2 "%s: (startMultiMediaTransmission) Checking codecs, local:%s, remote:%s\n", d->id,
+		sccp_codec_multiple2str(s1, sizeof(s1) - 1, channel->preferences.video, ARRAY_LEN(channel->preferences.video)),
+		sccp_codec_multiple2str(s2, sizeof(s2) - 1, channel->remoteCapabilities.video, ARRAY_LEN(channel->remoteCapabilities.video)));
+
+	// recalculate format;
+	if (channel->preferences.video[0] != SKINNY_CODEC_NONE && channel->remoteCapabilities.video[0] != SKINNY_CODEC_NONE) {
+		joint = sccp_codec_findBestJoint(channel->preferences.video, ARRAY_LEN(channel->preferences.video), channel->capabilities.video, ARRAY_LEN(channel->capabilities.video), channel->remoteCapabilities.video, ARRAY_LEN(channel->remoteCapabilities.video));
+		iPbx.rtp_setReadFormat(channel, joint);
+	}
+
+	if (joint == SKINNY_CODEC_NONE) {
+		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_2 "%s: (openMultiMediaReceiveChannel) No joint codecs found\n", d->id);
 		return;
 	}
+
+	if (!channel->rtp.video.instance && !sccp_rtp_createServer(d, (sccp_channel_t *)channel, SCCP_RTP_VIDEO)) {	// discard const
+		pbx_log(LOG_WARNING, "%s: can not start vrtp\n", d->id);
+	}
+
+	sccp_rtp_t *video = (sccp_rtp_t *) &(channel->rtp.video);
+
+	if (video->mediaTransmissionState != SCCP_RTP_STATUS_INACTIVE) {
+		pbx_log(LOG_WARNING, "%s: Receive Channel already in progress\\n", d->id);
+		return;
+	}
+
 	if (d->nat >= SCCP_NAT_ON) {										/* device is natted */
 		sccp_rtp_updateNatRemotePhone(channel, video);
 	}
 
-	// recalculate format;
-	{
-		// int packetSize;
-		video->readFormat = SKINNY_CODEC_H264;
-		iPbx.set_nativeVideoFormats(channel, SKINNY_CODEC_H264);
-		//// packetSize = 3840;
-		// packetSize = 1920;
-
-		//channel->preferences.video[0] = SKINNY_CODEC_H264;
-		//channel->preferences.video[1] = SKINNY_CODEC_H263;
-		skinny_codec_t *preferences = (skinny_codec_t *) &(channel->preferences.video);
-		preferences[0] = SKINNY_CODEC_H264;
-
-		video->readFormat = sccp_codec_findBestJoint(channel->preferences.video, ARRAY_LEN(channel->preferences.video), channel->capabilities.video, ARRAY_LEN(channel->capabilities.video), channel->remoteCapabilities.video, ARRAY_LEN(channel->remoteCapabilities.video));
-
-		if (video->readFormat == 0) {
-			sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: fall back to h264\n", d->id);
-			video->readFormat = SKINNY_CODEC_H264;
-		}
-
-		/* lookup payloadType */
-		payloadType = sccp_rtp_get_payloadType(&channel->rtp.video, video->readFormat);
-		//! \todo handle payload error
-		//! \todo use rtp codec map
-
-		//check if bind address is an global bind address
-		/*
-		if (!video->phone_remote.sin_addr.s_addr) {
-			video->phone_remote.sin_addr.s_addr = d->session->ourip.s_addr;
-		}
-		*/
-
-		sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: using payload %d\n", d->id, payloadType);
-		sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: using payload %d\n", d->id, payloadType);
-
-	}
 	video->mediaTransmissionState = SCCP_RTP_STATUS_PROGRESS;
-	d->protocol->sendStartMultiMediaTransmission(d, channel, payloadType, bitRate);
+	video->readFormat = joint;
+	int payloadType = sccp_rtp_get_payloadType(&channel->rtp.video, video->readFormat);
+	//! \todo handle payload error
+	//! \todo use rtp codec map
+
+	//check if bind address is an global bind address
+	/*
+	if (!video->phone_remote.sin_addr.s_addr) {
+		video->phone_remote.sin_addr.s_addr = d->session->ourip.s_addr;
+	}
+	*/
+	sccp_log((DEBUGCAT_RTP)) (VERBOSE_PREFIX_3 "%s: using payload %d\n", d->id, payloadType);
+
+	d->protocol->sendStartMultiMediaTransmission(d, channel, payloadType, channel->maxBitRate);
 
 	char buf1[NI_MAXHOST + NI_MAXSERV];
 	char buf2[NI_MAXHOST + NI_MAXSERV];
 	sccp_copy_string(buf1, sccp_netsock_stringify(&video->phone), sizeof(buf1));
 	sccp_copy_string(buf2, sccp_netsock_stringify(&video->phone_remote), sizeof(buf2));
 	sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: (startMultiMediaTransmission) Tell Phone to send VRTP/UDP media from %s to %s (NAT: %s)\n", d->id, buf1, buf2, sccp_nat2str(d->nat));
-
 	sccp_log(DEBUGCAT_RTP) (VERBOSE_PREFIX_3 "%s: (StartMultiMediaTransmission) Using codec: %s(%d), TOS %d for call with PassThruId: %u and CallID: %u\n", d->id, codec2str(video->readFormat), video->readFormat, d->video_tos, channel->passthrupartyid, channel->callid);
 
 	iPbx.queue_control(channel->owner, AST_CONTROL_VIDUPDATE);
@@ -1131,7 +1140,6 @@ void sccp_channel_stopMultiMediaTransmission(constChannelPtr channel, boolean_t 
 	}
 }
 
-#if UNUSEDCODE // 2015-11-01
 void sccp_channel_updateMultiMediaTransmission(constChannelPtr channel)
 {
 	if (SCCP_RTP_STATUS_INACTIVE != channel->rtp.video.mediaTransmissionState) {
@@ -1143,7 +1151,6 @@ void sccp_channel_updateMultiMediaTransmission(constChannelPtr channel)
 		sccp_channel_startMultiMediaTransmission(channel);
 	}
 }
-#endif
 
 void sccp_channel_closeAllMediaTransmitAndReceive(constDevicePtr d, constChannelPtr channel)
 {

--- a/src/sccp_channel.h
+++ b/src/sccp_channel.h
@@ -164,9 +164,9 @@ SCCP_API void SCCP_CALL sccp_channel_closeMultiMediaReceiveChannel(constChannelP
 #if UNUSEDCODE // 2015-11-01
 SCCP_API void SCCP_CALL sccp_channel_updateMultiMediaReceiveChannel(constChannelPtr channel);
 #endif
-#if UNUSEDCODE // 2015-11-01
+//#if UNUSEDCODE // 2015-11-01
 SCCP_API void SCCP_CALL sccp_channel_updateMultiMediaTransmission(constChannelPtr channel);
-#endif
+//#endif
 
 SCCP_API void SCCP_CALL sccp_channel_closeAllMediaTransmitAndReceive(constDevicePtr d, constChannelPtr channel);
 

--- a/src/sccp_cli.c
+++ b/src/sccp_cli.c
@@ -810,6 +810,12 @@ static int sccp_show_device(int fd, sccp_cli_totals_t *totals, struct mansession
 	CLI_AMI_OUTPUT_PARAM("Timezone Offset",		CLI_AMI_LIST_WIDTH, "%d", d->tz_offset);
 	CLI_AMI_OUTPUT_PARAM("Capabilities",		CLI_AMI_LIST_WIDTH, "%s", cap_buf);
 	CLI_AMI_OUTPUT_PARAM("Codecs preference",	CLI_AMI_LIST_WIDTH, "%s", pref_buf);
+#if CS_SCCP_VIDEO
+	sccp_codec_multiple2str(pref_buf, sizeof(pref_buf) - 1, d->preferences.video, ARRAY_LEN(d->preferences.video));
+	sccp_codec_multiple2str(cap_buf, sizeof(cap_buf) - 1, d->capabilities.video, ARRAY_LEN(d->capabilities.video));
+	CLI_AMI_OUTPUT_PARAM("Video Capabilities",	CLI_AMI_LIST_WIDTH, "%s", cap_buf);
+	CLI_AMI_OUTPUT_PARAM("Video Preferences",	CLI_AMI_LIST_WIDTH, "%s", pref_buf);
+#endif
 	CLI_AMI_OUTPUT_PARAM("Audio TOS",		CLI_AMI_LIST_WIDTH, "%d", d->audio_tos);
 	CLI_AMI_OUTPUT_PARAM("Audio COS",		CLI_AMI_LIST_WIDTH, "%d", d->audio_cos);
 	CLI_AMI_OUTPUT_PARAM("Video TOS",		CLI_AMI_LIST_WIDTH, "%d", d->video_tos);

--- a/src/sccp_codec.c
+++ b/src/sccp_codec.c
@@ -244,6 +244,21 @@ int sccp_codec_parseAllowDisallow(skinny_codec_t * skinny_codec_prefs, const cha
 	return errors;
 }
 
+int sccp_get_codecs_bytype(skinny_codec_t * in_codecs, skinny_codec_t *out_codecs, skinny_payload_type_t type)
+{
+	int x = 0, y = 0, z = 0;
+	for (x = 0; x < SKINNY_MAX_CAPABILITIES; x++) {
+		if (SKINNY_CODEC_NONE != in_codecs[x]) {
+			for (y = 0; y < sccp_codec_getArrayLen(); y++) {
+				if (skinny_codecs[y].codec == in_codecs[x] && skinny_codecs[y].codec_type == type) {
+					out_codecs[z++] = in_codecs[x];
+				}
+			}
+		}
+	}
+	return z;
+}
+
 /*!
  * \brief Check if Skinny Codec is compatible with Skinny Capabilities Array
  */
@@ -319,7 +334,7 @@ skinny_codec_t sccp_codec_findBestJoint(const skinny_codec_t ourPreferences[], i
 	uint8_t r, c, p;
 	skinny_codec_t firstJointCapability = SKINNY_CODEC_NONE;						/*!< used to get a default value */
 
-	sccp_log_and((DEBUGCAT_CODEC + DEBUGCAT_HIGH)) (VERBOSE_PREFIX_3 "pLength %d, cLength: %d, rLength: %d\n", pLength, cLength, rLength);
+	//sccp_log_and((DEBUGCAT_CODEC + DEBUGCAT_HIGH)) (VERBOSE_PREFIX_3 "pLength %d, cLength: %d, rLength: %d\n", pLength, cLength, rLength);
 
 	//char pref_buf[256];
 	//sccp_codec_multiple2str(pref_buf, sizeof(pref_buf) - 1, ourPreferences, (int)pLength);
@@ -344,7 +359,7 @@ skinny_codec_t sccp_codec_findBestJoint(const skinny_codec_t ourPreferences[], i
 			break;
 		}
 		/* no more preferences */
-		sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "preference: %d(%s)\n", ourPreferences[p], codec2name(ourPreferences[p]));
+		//sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "preference: %d(%s)\n", ourPreferences[p], codec2name(ourPreferences[p]));
 
 		/* check if we are capable to handle this codec */
 		for (c = 0; c < cLength; c++) {
@@ -353,33 +368,32 @@ skinny_codec_t sccp_codec_findBestJoint(const skinny_codec_t ourPreferences[], i
 				sccp_log_and((DEBUGCAT_CODEC + DEBUGCAT_HIGH)) ("Breaking at capability: %d\n", c);
 				break;
 			}
-
-			sccp_log_and((DEBUGCAT_CODEC + DEBUGCAT_HIGH)) (VERBOSE_PREFIX_3 "preference: %d(%s), capability: %d(%s)\n", ourPreferences[p], codec2name(ourPreferences[p]), ourCapabilities[c], codec2name(ourCapabilities[c]));
+			//sccp_log_and((DEBUGCAT_CODEC + DEBUGCAT_HIGH)) (VERBOSE_PREFIX_3 "preference: %d(%s), capability: %d(%s)\n", ourPreferences[p], codec2name(ourPreferences[p]), ourCapabilities[c], codec2name(ourCapabilities[c]));
 
 			/* we have no capabilities from the remote party, use the best codec from ourPreferences */
 			if (ourPreferences[p] == ourCapabilities[c]) {
 				if (firstJointCapability == SKINNY_CODEC_NONE) {
 					firstJointCapability = ourPreferences[p];
-					sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "found first firstJointCapability %d(%s)\n", firstJointCapability, codec2name(firstJointCapability));
+					//sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "found first firstJointCapability %d(%s)\n", firstJointCapability, codec2name(firstJointCapability));
 				}
 
 				if (rLength == 0 || remotePeerCapabilities[0] == SKINNY_CODEC_NONE) {
-					sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "Empty remote Capabilities, using bestCodec from firstJointCapability %d(%s)\n", firstJointCapability, codec2name(firstJointCapability));
+					//sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "Empty remote Capabilities, using bestCodec from firstJointCapability %d(%s)\n", firstJointCapability, codec2name(firstJointCapability));
 					return firstJointCapability;
 				} 
-					/* using capabilities from remote party, that matches our preferences & capabilities */
-					for (r = 0; r < rLength; r++) {
-						if (remotePeerCapabilities[r] == SKINNY_CODEC_NONE) {
-							sccp_log_and((DEBUGCAT_CODEC + DEBUGCAT_HIGH)) ("Breaking at remotePeerCapability: %d\n", c);
-							break;
-						}
-						sccp_log_and((DEBUGCAT_CODEC + DEBUGCAT_HIGH)) (VERBOSE_PREFIX_3 "preference: %d(%s), capability: %d(%s), remoteCapability: " UI64FMT "(%s)\n", ourPreferences[p], codec2name(ourPreferences[p]), ourCapabilities[c], codec2name(ourCapabilities[c]), (ULONG) remotePeerCapabilities[r], codec2name(remotePeerCapabilities[r]));
-						if (ourPreferences[p] == remotePeerCapabilities[r]) {
-							sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "found bestCodec as joint capability with remote peer %d(%s)\n", ourPreferences[p], codec2name(ourPreferences[p]));
-							return ourPreferences[p];
-						}
+
+				/* using capabilities from remote party, that matches our preferences & capabilities */
+				for (r = 0; r < rLength; r++) {
+					if (remotePeerCapabilities[r] == SKINNY_CODEC_NONE) {
+						//sccp_log_and((DEBUGCAT_CODEC + DEBUGCAT_HIGH)) ("Breaking at remotePeerCapability: %d\n", c);
+						break;
 					}
-				
+					sccp_log_and((DEBUGCAT_CODEC + DEBUGCAT_HIGH)) (VERBOSE_PREFIX_3 "preference: %d(%s), capability: %d(%s), remoteCapability: " UI64FMT "(%s)\n", ourPreferences[p], codec2name(ourPreferences[p]), ourCapabilities[c], codec2name(ourCapabilities[c]), (ULONG) remotePeerCapabilities[r], codec2name(remotePeerCapabilities[r]));
+					if (ourPreferences[p] == remotePeerCapabilities[r]) {
+						//sccp_log((DEBUGCAT_CODEC)) (VERBOSE_PREFIX_3 "found bestCodec as joint capability with remote peer %d(%s)\n", ourPreferences[p], codec2name(ourPreferences[p]));
+						return ourPreferences[p];
+					}
+				}
 			}
 		}
 	}

--- a/src/sccp_codec.h
+++ b/src/sccp_codec.h
@@ -129,6 +129,7 @@ SCCP_INLINE const char * SCCP_CALL codec2name(skinny_codec_t value);
 SCCP_INLINE const skinny_payload_type_t codec2type(skinny_codec_t value);
 SCCP_API char * SCCP_CALL sccp_codec_multiple2str(char *buf, size_t size, const skinny_codec_t * codecs, const int clength);
 SCCP_API int SCCP_CALL sccp_codec_parseAllowDisallow(skinny_codec_t * skinny_codec_prefs, const char *list, int allowing);
+SCCP_API int SCCP_CALL sccp_get_codecs_bytype(skinny_codec_t * in_codecs, skinny_codec_t *out_codecs, skinny_payload_type_t type);
 SCCP_API boolean_t __PURE__ SCCP_CALL sccp_codec_isCompatible(skinny_codec_t codec, const skinny_codec_t capabilities[], uint8_t length);
 SCCP_API void SCCP_CALL sccp_codec_reduceSet(skinny_codec_t base[SKINNY_MAX_CAPABILITIES], const skinny_codec_t reduceByCodecs[SKINNY_MAX_CAPABILITIES]);
 SCCP_API void SCCP_CALL sccp_codec_combineSets(skinny_codec_t base[SKINNY_MAX_CAPABILITIES], const skinny_codec_t addCodecs[SKINNY_MAX_CAPABILITIES]);

--- a/src/sccp_netsock.h
+++ b/src/sccp_netsock.h
@@ -91,7 +91,7 @@ static inline char * SCCP_CALL sccp_netsock_stringify_port(const struct sockaddr
 }
 
 /* end sccp_netsock_stringify_fmt short cuts */
-SCCP_API void SCCP_CALL sccp_netsock_setoptions(int new_socket, int reuse, int linger, int keepalive);
+SCCP_API void SCCP_CALL sccp_netsock_setoptions(int new_socket, int reuse, int linger, int keepalive, int sndtimeout, int rcvtimeout);
 SCCP_API void * SCCP_CALL sccp_netsock_thread(void *ignore);
 __END_C_EXTERN__
 // kate: indent-width 8; replace-tabs off; indent-mode cstyle; auto-insert-doxygen on; line-numbers on; tab-indents on; keep-extra-spaces off; auto-brackets off;

--- a/src/sccp_pbx.c
+++ b/src/sccp_pbx.c
@@ -795,7 +795,7 @@ uint8_t sccp_pbx_channel_allocate(sccp_channel_t * channel, const void *ids, con
 		return 0;
 	}
        	sccp_channel_updateChannelCapability(c);
-	iPbx.set_nativeAudioFormats(c, c->preferences.audio, 1);
+	//iPbx.set_nativeAudioFormats(c, c->preferences.audio, 1);
 	iPbx.setChannelName(c, c->designator);
 
 	// \todo: Bridge?

--- a/src/sccp_protocol.c
+++ b/src/sccp_protocol.c
@@ -669,6 +669,7 @@ static void sccp_protocol_sendOpenMultiMediaChannelV3(constDevicePtr device, con
 	msg->data.OpenMultiMediaChannelMessage.v3.videoParameter.confServiceNum = htolel(channel->callid);
 	msg->data.OpenMultiMediaChannelMessage.v3.videoParameter.bitRate = htolel(bitRate);
 
+	sccp_dump_msg(msg);
 	sccp_dev_send(device, msg);
 }
 
@@ -705,6 +706,7 @@ static void sccp_protocol_sendOpenMultiMediaChannelV17(constDevicePtr device, co
 	//msg->data.OpenMultiMediaChannelMessage.v17.videoParameter.dummy7                   = htolel(0);
 	//msg->data.OpenMultiMediaChannelMessage.v17.videoParameter.dummy8                   = htolel(0);
 
+	sccp_dump_msg(msg);
 	sccp_dev_send(device, msg);
 }
 
@@ -850,6 +852,7 @@ static void sccp_protocol_sendStartMultiMediaTransmissionV3(constDevicePtr devic
 		/* \todo add warning */
 	}
 
+	sccp_dump_msg(msg);
 	sccp_dev_send(device, msg);
 }
 
@@ -897,6 +900,7 @@ static void sccp_protocol_sendStartMultiMediaTransmissionV17(constDevicePtr devi
 
 		memcpy(&msg->data.StartMultiMediaTransmission.v17.bel_remoteIpAddr, &in->sin_addr, 4);
 	}
+	sccp_dump_msg(msg);
 	sccp_dev_send(device, msg);
 }
 

--- a/src/sccp_session.c
+++ b/src/sccp_session.c
@@ -815,7 +815,7 @@ static void *accept_thread(void *ignore)
 			continue;
 		}
 
-		sccp_netsock_setoptions(new_socket, /*reuse*/ -1, /*linger*/ 0, /* keepalive */ -1);
+		sccp_netsock_setoptions(new_socket, /*reuse*/ -1, /*linger*/ 0, /*keepalive*/ -1, /*sndtimeout*/ -1, /*rcvtimeout*/ 0);
 
 		if (!sccp_session_new_socket_allowed(&incoming)) {
 			close(new_socket);
@@ -924,7 +924,7 @@ boolean_t sccp_session_bind_and_listen(struct sockaddr_storage *bindaddr)
 				pbx_log(LOG_ERROR, "Unable to create SCCP socket: %s\n", strerror(errno));
 				break;
 			}
-			sccp_netsock_setoptions(accept_sock, /*reuse*/ 1, /*linger*/ -1, /*keepalive*/ -1);
+			sccp_netsock_setoptions(accept_sock, /*reuse*/ 1, /*linger*/ -1, /*keepalive*/ -1, /*sndtimeout*/0, /*rcvtimeout*/0);
 			if (bind(accept_sock, res->ai_addr, res->ai_addrlen) < 0) {
 				pbx_log(LOG_ERROR, "Failed to bind to %s:%d: %s!\n", addrStr, port, strerror(errno));
 				close(accept_sock);


### PR DESCRIPTION
Fix: Segfault cause by running conference on >asterisk-14 (NativeFormat was not set correctly when entering the brige)
Fix: Codec selection during channel_request
Enh: Update config allow/disallow handling for video codec preferences
Enh: Display video capabilies and preferences in CLI/AMI output
Fix: Erroneous use of rtp.audio where rtp.video was meant
Backport: Conference related fixed made for ast115 and ast114, backported to ast113

Fixes #400 